### PR TITLE
Persist and restore continue-watching state for TV and Anime via localStorage

### DIFF
--- a/pages/anime/[id].tsx
+++ b/pages/anime/[id].tsx
@@ -41,6 +41,7 @@ export default function AnimeDetailsPage() {
   const [seasonNumber, setSeasonNumber] = useState(1);
   const [episodeNumber, setEpisodeNumber] = useState(1);
   const [episodesCount, setEpisodesCount] = useState(0);
+  const [isProgressLoaded, setIsProgressLoaded] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
   const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false);
   const [downloadSources, setDownloadSources] = useState<SourceItem[]>([]);
@@ -65,40 +66,80 @@ export default function AnimeDetailsPage() {
   }, [id, animeType]);
 
   useEffect(() => {
-    if (!id || animeType !== "tv") return;
+    if (!id || animeType !== "tv") {
+      setIsProgressLoaded(true);
+      return;
+    }
 
-    const fetchSeason = async (season: number) => {
+    const storageId = Array.isArray(id) ? id[0] : id;
+    const storageKey = `continue:anime:tv:${storageId}`;
+
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (!stored) {
+        setIsProgressLoaded(true);
+        return;
+      }
+
+      const parsed = JSON.parse(stored) as { seasonNumber?: number; episodeNumber?: number };
+      const savedSeason = Number(parsed?.seasonNumber);
+      const savedEpisode = Number(parsed?.episodeNumber);
+
+      if (Number.isFinite(savedSeason) && savedSeason > 0) {
+        setSeasonNumber(savedSeason);
+      }
+
+      if (Number.isFinite(savedEpisode) && savedEpisode > 0) {
+        setEpisodeNumber(savedEpisode);
+      }
+    } catch {
+      // Ignore invalid localStorage data.
+    } finally {
+      setIsProgressLoaded(true);
+    }
+  }, [id, animeType]);
+
+  useEffect(() => {
+    if (!id || animeType !== "tv" || !isProgressLoaded) return;
+
+    const fetchSeason = async () => {
       try {
-        const { data } = await axios.get(`https://api.themoviedb.org/3/tv/${id}/season/${season}`, {
+        const { data } = await axios.get(`https://api.themoviedb.org/3/tv/${id}/season/${seasonNumber}`, {
           params: { api_key: process.env.NEXT_PUBLIC_TMDB_API_KEY },
         });
         const count = Array.isArray(data.episodes) ? data.episodes.length : 0;
         setEpisodesCount(count);
-        setEpisodeNumber(count > 0 ? 1 : 0);
+        setEpisodeNumber((current) => {
+          if (count === 0) return 0;
+          if (current > count) return 1;
+          return current > 0 ? current : 1;
+        });
       } catch {
         setEpisodesCount(0);
         setEpisodeNumber(0);
       }
     };
 
-    fetchSeason(1);
-  }, [id, animeType]);
+    fetchSeason();
+  }, [id, animeType, seasonNumber, isProgressLoaded]);
 
-  const handleSeasonChange = async (value: number) => {
-    if (!id) return;
+  useEffect(() => {
+    if (!id || animeType !== "tv" || !isProgressLoaded || seasonNumber <= 0 || episodeNumber <= 0) return;
 
+    const storageId = Array.isArray(id) ? id[0] : id;
+    const storageKey = `continue:anime:tv:${storageId}`;
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        seasonNumber,
+        episodeNumber,
+        updatedAt: new Date().toISOString(),
+      })
+    );
+  }, [id, animeType, seasonNumber, episodeNumber, isProgressLoaded]);
+
+  const handleSeasonChange = (value: number) => {
     setSeasonNumber(value);
-    try {
-      const { data } = await axios.get(`https://api.themoviedb.org/3/tv/${id}/season/${value}`, {
-        params: { api_key: process.env.NEXT_PUBLIC_TMDB_API_KEY },
-      });
-      const count = Array.isArray(data.episodes) ? data.episodes.length : 0;
-      setEpisodesCount(count);
-      setEpisodeNumber(count > 0 ? 1 : 0);
-    } catch {
-      setEpisodesCount(0);
-      setEpisodeNumber(0);
-    }
   };
 
   const title = anime?.title || anime?.name || "Untitled";

--- a/pages/tv/[id].tsx
+++ b/pages/tv/[id].tsx
@@ -28,6 +28,7 @@ export default function TVDetailsPage() {
   const [seasonNumber, setSeasonNumber] = useState(1);
   const [episodeNumber, setEpisodeNumber] = useState(1);
   const [episodesCount, setEpisodesCount] = useState(0);
+  const [isProgressLoaded, setIsProgressLoaded] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
   const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false);
   const [downloadSources, setDownloadSources] = useState<SourceItem[]>([]);
@@ -49,38 +50,77 @@ export default function TVDetailsPage() {
   }, [id]);
 
   useEffect(() => {
-    if (!tvShow || !id) return;
+    if (!id) return;
 
-    const fetchSeason = async (season: number) => {
+    const storageId = Array.isArray(id) ? id[0] : id;
+    const storageKey = `continue:tv:${storageId}`;
+
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (!stored) {
+        setIsProgressLoaded(true);
+        return;
+      }
+
+      const parsed = JSON.parse(stored) as { seasonNumber?: number; episodeNumber?: number };
+      const savedSeason = Number(parsed?.seasonNumber);
+      const savedEpisode = Number(parsed?.episodeNumber);
+
+      if (Number.isFinite(savedSeason) && savedSeason > 0) {
+        setSeasonNumber(savedSeason);
+      }
+
+      if (Number.isFinite(savedEpisode) && savedEpisode > 0) {
+        setEpisodeNumber(savedEpisode);
+      }
+    } catch {
+      // Ignore invalid localStorage data.
+    } finally {
+      setIsProgressLoaded(true);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    if (!tvShow || !id || !isProgressLoaded) return;
+
+    const fetchSeason = async () => {
       try {
-        const { data } = await axios.get(`https://api.themoviedb.org/3/tv/${id}/season/${season}`, {
+        const { data } = await axios.get(`https://api.themoviedb.org/3/tv/${id}/season/${seasonNumber}`, {
           params: { api_key: process.env.NEXT_PUBLIC_TMDB_API_KEY },
         });
         const count = Array.isArray(data.episodes) ? data.episodes.length : 0;
         setEpisodesCount(count);
-        setEpisodeNumber(count > 0 ? 1 : 0);
+        setEpisodeNumber((current) => {
+          if (count === 0) return 0;
+          if (current > count) return 1;
+          return current > 0 ? current : 1;
+        });
       } catch {
         setEpisodesCount(0);
         setEpisodeNumber(0);
       }
     };
 
-    fetchSeason(1);
-  }, [tvShow, id]);
+    fetchSeason();
+  }, [tvShow, id, seasonNumber, isProgressLoaded]);
 
-  const handleSeasonChange = async (value: number) => {
+  useEffect(() => {
+    if (!id || !isProgressLoaded || seasonNumber <= 0 || episodeNumber <= 0) return;
+
+    const storageId = Array.isArray(id) ? id[0] : id;
+    const storageKey = `continue:tv:${storageId}`;
+    window.localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        seasonNumber,
+        episodeNumber,
+        updatedAt: new Date().toISOString(),
+      })
+    );
+  }, [id, seasonNumber, episodeNumber, isProgressLoaded]);
+
+  const handleSeasonChange = (value: number) => {
     setSeasonNumber(value);
-    try {
-      const { data } = await axios.get(`https://api.themoviedb.org/3/tv/${id}/season/${value}`, {
-        params: { api_key: process.env.NEXT_PUBLIC_TMDB_API_KEY },
-      });
-      const count = Array.isArray(data.episodes) ? data.episodes.length : 0;
-      setEpisodesCount(count);
-      setEpisodeNumber(count > 0 ? 1 : 0);
-    } catch {
-      setEpisodesCount(0);
-      setEpisodeNumber(0);
-    }
   };
 
   const title = tvShow?.name || "Untitled";


### PR DESCRIPTION
### Motivation
- Let users continue where they left off by persisting selected `seasonNumber`/`episodeNumber` for series in browser storage. 
- Ensure resumed state is safe when episode counts differ between seasons by validating and clamping restored values.

### Description
- Added a progress load flag `isProgressLoaded` and restore flow that reads `localStorage` keys `continue:tv:<id>` and `continue:anime:tv:<id>` and applies saved `seasonNumber`/`episodeNumber` on page load. 
- Persist the current `seasonNumber`/`episodeNumber` to `localStorage` (payload includes `updatedAt`) whenever selections change and progress has finished loading. 
- Changed season fetch logic to request episode counts for the active `seasonNumber` (instead of always fetching season 1) and clamp `episodeNumber` to a valid range after the count is known. 
- Applied these changes to `pages/tv/[id].tsx` and `pages/anime/[id].tsx` and simplified the season-change handler to only update `seasonNumber` while relying on the fetch/validation effects.

### Testing
- Ran `npm run build`, which completed successfully. 
- Ran `npm run lint`, which failed due to the lint script resolving to an invalid Next.js directory (`Invalid project directory provided, no such directory: /workspace/ImpactStream/lint`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce8d80f59c8322967c931ba648be91)