### PR TITLE
Videasy overlay and watch-progress resume support

### DIFF
--- a/pages/anime/[id].tsx
+++ b/pages/anime/[id].tsx
@@ -41,6 +41,7 @@ export default function AnimeDetailsPage() {
   const [seasonNumber, setSeasonNumber] = useState(1);
   const [episodeNumber, setEpisodeNumber] = useState(1);
   const [episodesCount, setEpisodesCount] = useState(0);
+  const [resumeSeconds, setResumeSeconds] = useState(0);
   const [isProgressLoaded, setIsProgressLoaded] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
   const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false);
@@ -81,9 +82,14 @@ export default function AnimeDetailsPage() {
         return;
       }
 
-      const parsed = JSON.parse(stored) as { seasonNumber?: number; episodeNumber?: number };
+      const parsed = JSON.parse(stored) as {
+        seasonNumber?: number;
+        episodeNumber?: number;
+        timestamp?: number;
+      };
       const savedSeason = Number(parsed?.seasonNumber);
       const savedEpisode = Number(parsed?.episodeNumber);
+      const savedTimestamp = Math.floor(Number(parsed?.timestamp || 0));
 
       if (Number.isFinite(savedSeason) && savedSeason > 0) {
         setSeasonNumber(savedSeason);
@@ -92,6 +98,8 @@ export default function AnimeDetailsPage() {
       if (Number.isFinite(savedEpisode) && savedEpisode > 0) {
         setEpisodeNumber(savedEpisode);
       }
+
+      setResumeSeconds(savedTimestamp > 0 ? savedTimestamp : 0);
     } catch {
       // Ignore invalid localStorage data.
     } finally {
@@ -133,10 +141,92 @@ export default function AnimeDetailsPage() {
       JSON.stringify({
         seasonNumber,
         episodeNumber,
+        timestamp: 0,
         updatedAt: new Date().toISOString(),
       })
     );
   }, [id, animeType, seasonNumber, episodeNumber, isProgressLoaded]);
+
+  useEffect(() => {
+    if (!id || !isProgressLoaded) return;
+
+    const storageId = Array.isArray(id) ? id[0] : id;
+    const storageKey = `continue:anime:${animeType}:${storageId}`;
+
+    const handleProgressMessage = (event: MessageEvent) => {
+      if (event.origin !== "https://player.videasy.net") return;
+
+      const payload =
+        typeof event.data === "string"
+          ? (() => {
+              try {
+                return JSON.parse(event.data);
+              } catch {
+                return null;
+              }
+            })()
+          : event.data;
+
+      if (!payload || payload.type !== animeType) return;
+      if (String(payload.id) !== storageId) return;
+
+      const payloadSeason = Number(payload.season);
+      const payloadEpisode = Number(payload.episode);
+      if (animeType === "tv" && (payloadSeason !== seasonNumber || payloadEpisode !== episodeNumber)) return;
+
+      const timestamp = Math.max(0, Math.floor(Number(payload.timestamp || 0)));
+      const duration = Math.max(0, Math.floor(Number(payload.duration || 0)));
+      const progress = Math.max(0, Math.min(100, Number(payload.progress || 0)));
+
+      window.localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          seasonNumber: animeType === "tv" ? seasonNumber : 1,
+          episodeNumber: animeType === "tv" ? episodeNumber : 1,
+          timestamp,
+          duration,
+          progress,
+          updatedAt: new Date().toISOString(),
+        })
+      );
+    };
+
+    window.addEventListener("message", handleProgressMessage);
+    return () => window.removeEventListener("message", handleProgressMessage);
+  }, [id, animeType, isProgressLoaded, seasonNumber, episodeNumber]);
+
+  useEffect(() => {
+    if (!id || !isProgressLoaded) return;
+
+    const storageId = Array.isArray(id) ? id[0] : id;
+    const storageKey = `continue:anime:${animeType}:${storageId}`;
+
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (!stored) {
+        setResumeSeconds(0);
+        return;
+      }
+
+      const parsed = JSON.parse(stored) as {
+        seasonNumber?: number;
+        episodeNumber?: number;
+        timestamp?: number;
+      };
+      if (
+        animeType === "tv" &&
+        (Number(parsed.seasonNumber) !== seasonNumber || Number(parsed.episodeNumber) !== episodeNumber)
+      ) {
+        setResumeSeconds(0);
+        return;
+      }
+
+      const savedTimestamp = Math.floor(Number(parsed.timestamp || 0));
+      setResumeSeconds(savedTimestamp > 0 ? savedTimestamp : 0);
+    } catch {
+      setResumeSeconds(0);
+    }
+  }, [id, animeType, isProgressLoaded, seasonNumber, episodeNumber]);
 
   const handleSeasonChange = (value: number) => {
     setSeasonNumber(value);
@@ -154,12 +244,33 @@ export default function AnimeDetailsPage() {
 
   const streamUrl = useMemo(() => {
     if (!id) return "";
+    const mediaId = Array.isArray(id) ? id[0] : id;
+
     if (animeType === "movie") {
-      return `https://player.videasy.net/movie/${id}?color=e50914&nextEpisode=true&episodeSelector=true`;
+      const query = new URLSearchParams({
+        color: "e50914",
+        nextEpisode: "true",
+        episodeSelector: "true",
+        overlay: "true",
+      });
+      if (resumeSeconds > 0) {
+        query.set("progress", String(resumeSeconds));
+      }
+      return `https://player.videasy.net/movie/${mediaId}?${query.toString()}`;
     }
 
-    return `https://player.videasy.net/tv/${id}/${seasonNumber}/${episodeNumber}?color=e50914&nextEpisode=true&episodeSelector=true&autoplayNextEpisode=true`;
-  }, [id, animeType, seasonNumber, episodeNumber]);
+    const query = new URLSearchParams({
+      color: "e50914",
+      nextEpisode: "true",
+      episodeSelector: "true",
+      autoplayNextEpisode: "true",
+      overlay: "true",
+    });
+    if (resumeSeconds > 0) {
+      query.set("progress", String(resumeSeconds));
+    }
+    return `https://player.videasy.net/tv/${mediaId}/${seasonNumber}/${episodeNumber}?${query.toString()}`;
+  }, [id, animeType, seasonNumber, episodeNumber, resumeSeconds]);
 
   const metadata = useMemo(() => {
     const base = [

--- a/pages/movie/[id].tsx
+++ b/pages/movie/[id].tsx
@@ -25,12 +25,73 @@ export default function MovieDetailsPage() {
   const router = useRouter();
   const { id } = router.query;
   const [movie, setMovie] = useState<MovieDetails | null>(null);
+  const [resumeSeconds, setResumeSeconds] = useState(0);
   const [isDownloading, setIsDownloading] = useState(false);
   const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false);
   const [downloadSources, setDownloadSources] = useState<SourceItem[]>([]);
   const [downloadSubtitles, setDownloadSubtitles] = useState<SubtitleItem[]>([]);
   const [downloadError, setDownloadError] = useState("");
   const [downloadTitle, setDownloadTitle] = useState("");
+
+  useEffect(() => {
+    if (!id) return;
+
+    const storageId = Array.isArray(id) ? id[0] : id;
+    const storageKey = `continue:movie:${storageId}`;
+
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (!stored) return;
+
+      const parsed = JSON.parse(stored) as { timestamp?: number };
+      const savedTimestamp = Math.floor(Number(parsed?.timestamp || 0));
+      setResumeSeconds(savedTimestamp > 0 ? savedTimestamp : 0);
+    } catch {
+      setResumeSeconds(0);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    if (!id) return;
+
+    const storageId = Array.isArray(id) ? id[0] : id;
+    const storageKey = `continue:movie:${storageId}`;
+
+    const handleProgressMessage = (event: MessageEvent) => {
+      if (event.origin !== "https://player.videasy.net") return;
+
+      const payload =
+        typeof event.data === "string"
+          ? (() => {
+              try {
+                return JSON.parse(event.data);
+              } catch {
+                return null;
+              }
+            })()
+          : event.data;
+
+      if (!payload || payload.type !== "movie") return;
+      if (String(payload.id) !== storageId) return;
+
+      const timestamp = Math.max(0, Math.floor(Number(payload.timestamp || 0)));
+      const duration = Math.max(0, Math.floor(Number(payload.duration || 0)));
+      const progress = Math.max(0, Math.min(100, Number(payload.progress || 0)));
+
+      window.localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          timestamp,
+          duration,
+          progress,
+          updatedAt: new Date().toISOString(),
+        })
+      );
+    };
+
+    window.addEventListener("message", handleProgressMessage);
+    return () => window.removeEventListener("message", handleProgressMessage);
+  }, [id]);
 
   useEffect(() => {
     if (!id) return;
@@ -72,6 +133,17 @@ export default function MovieDetailsPage() {
 
   if (!movie) return <div className="loading">Loading...</div>;
 
+  const movieId = Array.isArray(id) ? id[0] : id;
+  const movieQuery = new URLSearchParams({
+    color: "e50914",
+    nextEpisode: "true",
+    episodeSelector: "true",
+    overlay: "true",
+  });
+  if (resumeSeconds > 0) {
+    movieQuery.set("progress", String(resumeSeconds));
+  }
+
   const handleDownload = async () => {
     const tmdbId = Number(Array.isArray(id) ? id[0] : id);
     if (!tmdbId) return;
@@ -107,7 +179,7 @@ export default function MovieDetailsPage() {
         mediaLabel="Movie"
         title={title}
         summary={movie.overview || "No overview is available for this title yet."}
-        embedUrl={`https://player.videasy.net/movie/${id}?color=e50914&nextEpisode=true&episodeSelector=true`}
+        embedUrl={`https://player.videasy.net/movie/${movieId}?${movieQuery.toString()}`}
         posterUrl={posterUrl}
         backdropUrl={backdropUrl}
         metadata={metadata}

--- a/pages/tv/[id].tsx
+++ b/pages/tv/[id].tsx
@@ -28,6 +28,7 @@ export default function TVDetailsPage() {
   const [seasonNumber, setSeasonNumber] = useState(1);
   const [episodeNumber, setEpisodeNumber] = useState(1);
   const [episodesCount, setEpisodesCount] = useState(0);
+  const [resumeSeconds, setResumeSeconds] = useState(0);
   const [isProgressLoaded, setIsProgressLoaded] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
   const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false);
@@ -62,9 +63,14 @@ export default function TVDetailsPage() {
         return;
       }
 
-      const parsed = JSON.parse(stored) as { seasonNumber?: number; episodeNumber?: number };
+      const parsed = JSON.parse(stored) as {
+        seasonNumber?: number;
+        episodeNumber?: number;
+        timestamp?: number;
+      };
       const savedSeason = Number(parsed?.seasonNumber);
       const savedEpisode = Number(parsed?.episodeNumber);
+      const savedTimestamp = Math.floor(Number(parsed?.timestamp || 0));
 
       if (Number.isFinite(savedSeason) && savedSeason > 0) {
         setSeasonNumber(savedSeason);
@@ -73,6 +79,8 @@ export default function TVDetailsPage() {
       if (Number.isFinite(savedEpisode) && savedEpisode > 0) {
         setEpisodeNumber(savedEpisode);
       }
+
+      setResumeSeconds(savedTimestamp > 0 ? savedTimestamp : 0);
     } catch {
       // Ignore invalid localStorage data.
     } finally {
@@ -114,10 +122,89 @@ export default function TVDetailsPage() {
       JSON.stringify({
         seasonNumber,
         episodeNumber,
+        timestamp: 0,
         updatedAt: new Date().toISOString(),
       })
     );
   }, [id, seasonNumber, episodeNumber, isProgressLoaded]);
+
+  useEffect(() => {
+    if (!id || !isProgressLoaded || seasonNumber <= 0 || episodeNumber <= 0) return;
+
+    const storageId = Array.isArray(id) ? id[0] : id;
+    const storageKey = `continue:tv:${storageId}`;
+
+    const handleProgressMessage = (event: MessageEvent) => {
+      if (event.origin !== "https://player.videasy.net") return;
+
+      const payload =
+        typeof event.data === "string"
+          ? (() => {
+              try {
+                return JSON.parse(event.data);
+              } catch {
+                return null;
+              }
+            })()
+          : event.data;
+
+      if (!payload || payload.type !== "tv") return;
+      if (String(payload.id) !== storageId) return;
+
+      const payloadSeason = Number(payload.season);
+      const payloadEpisode = Number(payload.episode);
+      if (payloadSeason !== seasonNumber || payloadEpisode !== episodeNumber) return;
+
+      const timestamp = Math.max(0, Math.floor(Number(payload.timestamp || 0)));
+      const duration = Math.max(0, Math.floor(Number(payload.duration || 0)));
+      const progress = Math.max(0, Math.min(100, Number(payload.progress || 0)));
+
+      window.localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          seasonNumber,
+          episodeNumber,
+          timestamp,
+          duration,
+          progress,
+          updatedAt: new Date().toISOString(),
+        })
+      );
+    };
+
+    window.addEventListener("message", handleProgressMessage);
+    return () => window.removeEventListener("message", handleProgressMessage);
+  }, [id, isProgressLoaded, seasonNumber, episodeNumber]);
+
+  useEffect(() => {
+    if (!id || !isProgressLoaded || seasonNumber <= 0 || episodeNumber <= 0) return;
+
+    const storageId = Array.isArray(id) ? id[0] : id;
+    const storageKey = `continue:tv:${storageId}`;
+
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (!stored) {
+        setResumeSeconds(0);
+        return;
+      }
+
+      const parsed = JSON.parse(stored) as {
+        seasonNumber?: number;
+        episodeNumber?: number;
+        timestamp?: number;
+      };
+      if (Number(parsed.seasonNumber) !== seasonNumber || Number(parsed.episodeNumber) !== episodeNumber) {
+        setResumeSeconds(0);
+        return;
+      }
+
+      const savedTimestamp = Math.floor(Number(parsed.timestamp || 0));
+      setResumeSeconds(savedTimestamp > 0 ? savedTimestamp : 0);
+    } catch {
+      setResumeSeconds(0);
+    }
+  }, [id, isProgressLoaded, seasonNumber, episodeNumber]);
 
   const handleSeasonChange = (value: number) => {
     setSeasonNumber(value);
@@ -148,6 +235,17 @@ export default function TVDetailsPage() {
   );
 
   if (!tvShow) return <div className="loading">Loading...</div>;
+  const tvId = Array.isArray(id) ? id[0] : id;
+  const tvQuery = new URLSearchParams({
+    color: "e50914",
+    nextEpisode: "true",
+    episodeSelector: "true",
+    autoplayNextEpisode: "true",
+    overlay: "true",
+  });
+  if (resumeSeconds > 0) {
+    tvQuery.set("progress", String(resumeSeconds));
+  }
 
   const handleDownload = async () => {
     const tmdbId = Number(Array.isArray(id) ? id[0] : id);
@@ -189,7 +287,7 @@ export default function TVDetailsPage() {
         mediaLabel="Series"
         title={title}
         summary={tvShow.overview || "No overview is available for this series yet."}
-        embedUrl={`https://player.videasy.net/tv/${id}/${seasonNumber}/${episodeNumber}?color=e50914&nextEpisode=true&episodeSelector=true&autoplayNextEpisode=true`}
+        embedUrl={`https://player.videasy.net/tv/${tvId}/${seasonNumber}/${episodeNumber}?${tvQuery.toString()}`}
         posterUrl={posterUrl}
         backdropUrl={backdropUrl}
         metadata={metadata}


### PR DESCRIPTION
### Motivation
- Provide a Netflix-style overlay and resume playback behavior for embedded Videasy players. 
- Persist and restore watch progress so users can continue movies or specific TV/anime episodes where they left off.

### Description
- Enabled the Videasy overlay by adding `overlay=true` to embed URLs and built query strings for movies, TV, and anime in `pages/movie/[id].tsx`, `pages/tv/[id].tsx`, and `pages/anime/[id].tsx`.
- Added `resumeSeconds` state and logic to read saved progress from `localStorage` keys like `continue:movie:{id}`, `continue:tv:{id}`, and `continue:anime:{type}:{id}` and include `progress={seconds}` in the player URL when available.
- Added `message` event listeners that accept postMessage payloads from `https://player.videasy.net`, parse `timestamp`, `duration`, and `progress`, and persist them (including `seasonNumber`/`episodeNumber` for series) into `localStorage` to avoid cross-episode resume conflicts.
- Kept season/episode-aware behavior for TV and anime so saved timestamps only apply to the matching episode and added safeguards when loading/storing progress.

### Testing
- Ran `npx tsc --noEmit` which completed successfully.
- Ran `npm run lint` which failed in this environment with `Invalid project directory provided, no such directory: /workspace/ImpactStream/lint` (lint issue unrelated to these code changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce8fea6ab88322ba45c65fd6848013)