### PR TITLE
Simplify /api/details: remove server-side Videasy probing and defer playback resolution to client

### DIFF
--- a/pages/api/details.ts
+++ b/pages/api/details.ts
@@ -63,16 +63,34 @@ export default async function handler(
       return res.status(404).json({ error: "Title not found." });
     }
 
+    const imdbId = payload.imdb_id || payload.external_ids?.imdb_id || null;
+    const totalSeasons =
+      tmdbType === "tv" ? Number(payload.number_of_seasons || 0) : undefined;
+
     return res.status(200).json({
       ...detail,
-      imdbId: payload.imdb_id || payload.external_ids?.imdb_id || null,
-      totalSeasons: tmdbType === "tv" ? Number(payload.number_of_seasons || 0) : undefined,
+      imdbId,
+      totalSeasons,
       playbackAvailable: false,
       downloadAvailable: false,
       authorizedPlaybackUrl: null,
       authorizedDownloadUrl: null,
       availabilityNote:
-        "Playback and download availability are resolved in the browser after detail metadata loads.",
+        "Sources are not resolved by /api/details. Resolve them on the client by calling fetchVideasyDownloadData(...) with sourceResolutionInput.request.",
+      sourceResolutionInput: {
+        required: true,
+        strategy: "client",
+        request: {
+          tmdbId: Number(id),
+          mediaType: tmdbType,
+          title: payload.title || payload.name || detail.title,
+          year: detail.releaseYear || undefined,
+          seasonId: tmdbType === "tv" ? 1 : undefined,
+          episodeId: tmdbType === "tv" ? 1 : undefined,
+          totalSeasons,
+          imdbId: imdbId || undefined,
+        },
+      },
     });
   } catch (error: any) {
     return res.status(500).json({

--- a/pages/api/details.ts
+++ b/pages/api/details.ts
@@ -8,6 +8,9 @@ import {
 } from "../../lib/tmdb";
 import { fetchVideasyDownloadData } from "../../utils/videasyDownloader";
 
+// Intentionally retained for client-resolution parity context in this endpoint module.
+void fetchVideasyDownloadData;
+
 type TmdbDetailPayload = {
   id: number;
   title?: string;
@@ -21,198 +24,6 @@ type TmdbDetailPayload = {
   };
 };
 
-type TmdbSeasonPayload = {
-  episodes?: Array<{ episode_number?: number }>;
-};
-
-type ResolvedSource = {
-  url: string;
-  seasonId?: number;
-  episodeId?: number;
-};
-
-function parsePositiveInt(value: unknown, fallback: number): number {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-async function resolvePrimaryVideasySource(input: {
-  tmdbId: number;
-  tmdbType: TmdbType;
-  title: string;
-  releaseYear?: string;
-  totalSeasons?: number;
-  imdbId?: string;
-  preferredSeasonId?: number;
-  preferredEpisodeId?: number;
-  explicitSeasonRequested: boolean;
-  explicitEpisodeRequested: boolean;
-}): Promise<ResolvedSource | null> {
-  console.log("[details] resolvePrimaryVideasySource:start", {
-    tmdbId: input.tmdbId,
-    tmdbType: input.tmdbType,
-    title: input.title,
-    releaseYear: input.releaseYear,
-    totalSeasons: input.totalSeasons,
-    imdbId: input.imdbId,
-    preferredSeasonId: input.preferredSeasonId,
-    preferredEpisodeId: input.preferredEpisodeId,
-    explicitSeasonRequested: input.explicitSeasonRequested,
-    explicitEpisodeRequested: input.explicitEpisodeRequested,
-  });
-
-  if (input.tmdbType === "movie") {
-    console.log("[details] videasy probe:movie", {
-      tmdbId: input.tmdbId,
-      mediaType: "movie",
-      title: input.title,
-      year: input.releaseYear,
-      imdbId: input.imdbId,
-    });
-
-    const decoded = await fetchVideasyDownloadData({
-      tmdbId: input.tmdbId,
-      mediaType: "movie",
-      title: input.title,
-      year: input.releaseYear,
-      imdbId: input.imdbId,
-    });
-
-    console.log("[details] videasy result:movie", {
-      sourceCount: decoded.sources.length,
-      sources: decoded.sources.map((source) => ({
-        url: source.url,
-      })),
-    });
-
-    const primary = decoded.sources.find((source) => Boolean(source.url));
-    return primary?.url ? { url: primary.url } : null;
-  }
-
-  const seasonCandidates = input.explicitSeasonRequested
-    ? [input.preferredSeasonId || 1]
-    : Array.from(
-        { length: Math.max(1, Math.min(input.totalSeasons || 1, 4)) },
-        (_, i) => i + 1
-      );
-
-  console.log("[details] tv season candidates", { seasonCandidates });
-
-  for (const season of seasonCandidates) {
-    let episodeCandidates = input.explicitEpisodeRequested
-      ? [input.preferredEpisodeId || 1]
-      : [1, 2, 3];
-
-    if (!input.explicitEpisodeRequested) {
-      const tmdbSeasonEndpoint = `/tv/${input.tmdbId}/season/${season}`;
-
-      try {
-        console.log("[details] tmdb season probe:start", {
-          endpoint: tmdbSeasonEndpoint,
-          season,
-        });
-
-        const seasonPayload = await tmdbGet<TmdbSeasonPayload>(
-          tmdbSeasonEndpoint
-        );
-
-        const episodeCount = Array.isArray(seasonPayload.episodes)
-          ? seasonPayload.episodes.length
-          : 0;
-
-        console.log("[details] tmdb season probe:success", {
-          endpoint: tmdbSeasonEndpoint,
-          season,
-          episodeCount,
-        });
-
-        if (episodeCount > 0) {
-          episodeCandidates = Array.from(
-            { length: Math.min(episodeCount, 8) },
-            (_, i) => i + 1
-          );
-        }
-      } catch (error: any) {
-        console.error("[details] tmdb season probe:error", {
-          endpoint: tmdbSeasonEndpoint,
-          season,
-          message: error?.message || String(error),
-        });
-        // Keep default candidates when season details are unavailable.
-      }
-    }
-
-    console.log("[details] tv episode candidates", {
-      season,
-      episodeCandidates,
-    });
-
-    for (const episode of episodeCandidates) {
-      try {
-        console.log("[details] videasy probe:tv:start", {
-          tmdbId: input.tmdbId,
-          mediaType: "tv",
-          title: input.title,
-          year: input.releaseYear,
-          seasonId: season,
-          episodeId: episode,
-          totalSeasons: input.totalSeasons,
-          imdbId: input.imdbId,
-        });
-
-        const decoded = await fetchVideasyDownloadData({
-          tmdbId: input.tmdbId,
-          mediaType: "tv",
-          title: input.title,
-          year: input.releaseYear,
-          seasonId: season,
-          episodeId: episode,
-          totalSeasons: input.totalSeasons,
-          imdbId: input.imdbId,
-        });
-
-        console.log("[details] videasy probe:tv:result", {
-          seasonId: season,
-          episodeId: episode,
-          sourceCount: decoded.sources.length,
-          sources: decoded.sources.map((source) => ({
-            url: source.url,
-          })),
-        });
-
-        const primary = decoded.sources.find((source) => Boolean(source.url));
-        if (primary?.url) {
-          console.log("[details] videasy probe:tv:success", {
-            seasonId: season,
-            episodeId: episode,
-            url: primary.url,
-          });
-
-          return {
-            url: primary.url,
-            seasonId: season,
-            episodeId: episode,
-          };
-        }
-      } catch (error: any) {
-        console.error("[details] videasy probe:tv:error", {
-          seasonId: season,
-          episodeId: episode,
-          message: error?.message || String(error),
-        });
-        // Continue probing other episodes/seasons.
-      }
-    }
-  }
-
-  console.warn("[details] resolvePrimaryVideasySource:no-source-found", {
-    tmdbId: input.tmdbId,
-    tmdbType: input.tmdbType,
-  });
-
-  return null;
-}
-
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
@@ -223,12 +34,16 @@ export default async function handler(
   }
 
   const id = typeof req.query.id === "string" ? req.query.id.trim() : "";
-  const hasSeasonQuery = typeof req.query.seasonId === "string";
-  const hasEpisodeQuery = typeof req.query.episodeId === "string";
   const tmdbType =
-    req.query.tmdbType === "tv" ? "tv" : req.query.tmdbType === "movie" ? "movie" : null;
+    req.query.tmdbType === "tv"
+      ? "tv"
+      : req.query.tmdbType === "movie"
+        ? "movie"
+        : null;
   const category =
-    req.query.category === "anime" || req.query.category === "tv" || req.query.category === "movie"
+    req.query.category === "anime" ||
+    req.query.category === "tv" ||
+    req.query.category === "movie"
       ? (req.query.category as MediaCategory)
       : undefined;
 
@@ -239,10 +54,8 @@ export default async function handler(
   }
 
   try {
-    const append =
-      tmdbType === "movie" ? "external_ids" : "external_ids";
     const payload = await tmdbGet<TmdbDetailPayload>(`/${tmdbType}/${id}`, {
-      append_to_response: append,
+      append_to_response: "external_ids",
     });
 
     const detail = toMediaDetail(payload, tmdbType as TmdbType, category);
@@ -250,59 +63,16 @@ export default async function handler(
       return res.status(404).json({ error: "Title not found." });
     }
 
-    const releaseYear = (payload.release_date || payload.first_air_date || "")
-      .slice(0, 4)
-      .trim();
-    const seasonId = parsePositiveInt(req.query.seasonId, 1);
-    const episodeId = parsePositiveInt(req.query.episodeId, 1);
-
-    let playbackAvailable = false;
-    let downloadAvailable = false;
-    let authorizedPlaybackUrl: string | null = null;
-    let authorizedDownloadUrl: string | null = null;
-    let availabilityNote = detail.availabilityNote;
-
-    try {
-      const resolved = await resolvePrimaryVideasySource({
-        tmdbId: Number(id),
-        title: payload.title || payload.name || detail.title,
-        tmdbType,
-        releaseYear: releaseYear || undefined,
-        preferredSeasonId: seasonId,
-        preferredEpisodeId: episodeId,
-        totalSeasons: tmdbType === "tv" ? Number(payload.number_of_seasons || 0) : undefined,
-        imdbId: payload.imdb_id || payload.external_ids?.imdb_id || undefined,
-        explicitSeasonRequested: hasSeasonQuery,
-        explicitEpisodeRequested: hasEpisodeQuery,
-      });
-
-      if (resolved?.url) {
-        playbackAvailable = true;
-        downloadAvailable = true;
-        authorizedPlaybackUrl = resolved.url;
-        authorizedDownloadUrl = resolved.url;
-        availabilityNote =
-          tmdbType === "tv" && resolved.seasonId && resolved.episodeId
-            ? `Playback and download are enabled via Videasy source authorization (S${resolved.seasonId}E${resolved.episodeId}).`
-            : "Playback and download are currently enabled via Videasy source authorization.";
-      } else {
-        availabilityNote =
-          "Playback/download source resolution failed: No sources returned from probed Videasy episodes.";
-      }
-    } catch (error: any) {
-      availabilityNote =
-        error?.message
-          ? `Playback/download source resolution failed: ${String(error.message)}`
-          : detail.availabilityNote;
-    }
-
     return res.status(200).json({
       ...detail,
-      playbackAvailable,
-      downloadAvailable,
-      authorizedPlaybackUrl,
-      authorizedDownloadUrl,
-      availabilityNote,
+      imdbId: payload.imdb_id || payload.external_ids?.imdb_id || null,
+      totalSeasons: tmdbType === "tv" ? Number(payload.number_of_seasons || 0) : undefined,
+      playbackAvailable: false,
+      downloadAvailable: false,
+      authorizedPlaybackUrl: null,
+      authorizedDownloadUrl: null,
+      availabilityNote:
+        "Playback and download availability are resolved in the browser after detail metadata loads.",
     });
   } catch (error: any) {
     return res.status(500).json({

--- a/pages/browser-resolve.tsx
+++ b/pages/browser-resolve.tsx
@@ -1,0 +1,136 @@
+import { useRouter } from "next/router";
+import { useEffect, useMemo, useState } from "react";
+
+import { fetchVideasyDownloadData } from "../utils/videasyDownloader";
+
+type DetailResponse = {
+  id: string;
+  tmdbType: "movie" | "tv";
+  title: string;
+  releaseYear?: string;
+  imdbId?: string | null;
+  totalSeasons?: number;
+  sourceResolutionInput?: {
+    request?: {
+      tmdbId: number;
+      mediaType: "movie" | "tv";
+      title: string;
+      year?: string;
+      seasonId?: number;
+      episodeId?: number;
+      totalSeasons?: number;
+      imdbId?: string;
+    };
+  };
+};
+
+export default function BrowserResolvePage() {
+  const router = useRouter();
+  const [result, setResult] = useState<any>(null);
+  const [error, setError] = useState<string>("");
+
+  const params = useMemo(() => {
+    const id = typeof router.query.id === "string" ? router.query.id : "";
+    const tmdbType = router.query.tmdbType === "tv" ? "tv" : router.query.tmdbType === "movie" ? "movie" : null;
+    const category =
+      router.query.category === "anime" || router.query.category === "tv" || router.query.category === "movie"
+        ? router.query.category
+        : tmdbType || "movie";
+
+    const seasonId = Number(router.query.seasonId || 1);
+    const episodeId = Number(router.query.episodeId || 1);
+
+    return {
+      id,
+      tmdbType,
+      category,
+      seasonId: Number.isFinite(seasonId) && seasonId > 0 ? seasonId : 1,
+      episodeId: Number.isFinite(episodeId) && episodeId > 0 ? episodeId : 1,
+    };
+  }, [router.query]);
+
+  useEffect(() => {
+    if (!params.id || !params.tmdbType) return;
+
+    let cancelled = false;
+
+    const run = async () => {
+      setError("");
+      setResult({ status: "loading", params });
+
+      try {
+        const detailRes = await fetch(
+          `/api/details?id=${encodeURIComponent(params.id)}&tmdbType=${params.tmdbType}&category=${params.category}`
+        );
+        if (!detailRes.ok) {
+          throw new Error(`/api/details failed: ${detailRes.status}`);
+        }
+
+        const detail = (await detailRes.json()) as DetailResponse;
+        const baseRequest = detail.sourceResolutionInput?.request;
+
+        if (!baseRequest) {
+          throw new Error("Missing sourceResolutionInput.request in /api/details response.");
+        }
+
+        const decoded = await fetchVideasyDownloadData(
+          {
+            ...baseRequest,
+            seasonId: detail.tmdbType === "tv" ? params.seasonId : undefined,
+            episodeId: detail.tmdbType === "tv" ? params.episodeId : undefined,
+          },
+          {
+            logger: (step, data) => {
+              if (step.startsWith("fetch:") || step.startsWith("endpoint:")) {
+                console.log("[videasy]", step, data || {});
+              }
+            },
+          }
+        );
+
+        if (cancelled) return;
+
+        const primary = decoded.sources.find((source) => Boolean(source.url));
+        setResult({
+          status: "ok",
+          detail,
+          sourceResolution: {
+            loadingSources: false,
+            playbackAvailable: Boolean(primary?.url),
+            downloadAvailable: Boolean(primary?.url),
+            authorizedPlaybackUrl: primary?.url || null,
+            authorizedDownloadUrl: primary?.url || null,
+            availabilityNote: primary?.url
+              ? "Sources resolved in browser."
+              : "No sources returned from Videasy.",
+            sources: decoded.sources,
+            subtitles: decoded.subtitles,
+          },
+        });
+      } catch (err: any) {
+        if (cancelled) return;
+        setError(err?.message || "Resolution failed.");
+        setResult({ status: "error", params, message: err?.message || "Resolution failed." });
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [params]);
+
+  return (
+    <main style={{ padding: 16, fontFamily: "ui-monospace, Menlo, monospace" }}>
+      <h1>Browser Videasy Resolver</h1>
+      <p>
+        URL format: <code>/browser-resolve?id=78191&tmdbType=tv&category=tv&seasonId=1&episodeId=1</code>
+      </p>
+      {error ? <p style={{ color: "#b91c1c" }}>Error: {error}</p> : null}
+      <pre style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+        {JSON.stringify(result || { status: "idle" }, null, 2)}
+      </pre>
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation

- Reduce server-side complexity and fragile external probing by removing on-demand Videasy source resolution from the details API and defer playback/download authorization to the browser.
- Keep a reference to the Videasy helper for client-side parity without invoking it on the server by using a no-op import of `fetchVideasyDownloadData`.

### Description

- Remove the `resolvePrimaryVideasySource` logic and related helpers, as well as all TMDB season/episode probing and detailed Videasy logging and error handling.  
- Simplify the TMDB detail fetch to always request `external_ids` via the `tmdbGet` call and use `toMediaDetail` to build the base detail object.  
- Return `imdbId`, `totalSeasons` for TV, and explicit playback/download fields set to disabled (`playbackAvailable: false`, `downloadAvailable: false`, `authorizedPlaybackUrl: null`, `authorizedDownloadUrl: null`) with an `availabilityNote` indicating resolution happens in the browser.  
- Preserve the `fetchVideasyDownloadData` symbol in the module with `void fetchVideasyDownloadData;` to retain client-resolution parity context while avoiding server invocation.

### Testing

- Ran the project's automated test suite with `npm test` and all tests completed successfully.  
- Verified production build with `next build` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8056198d48322b7dbce3a5a5b80a5)