### PR TITLE
Client-side Videasy custom player (Dart-aligned HLS + options)

### DIFF
--- a/components/MediaDetailShell.tsx
+++ b/components/MediaDetailShell.tsx
@@ -1,4 +1,6 @@
 import { ReactNode } from "react";
+import type { DownloadRequest } from "../utils/videasyDownloader";
+import VideasyCustomPlayer, { type VideasyCustomPlayerContinueConfig } from "./VideasyCustomPlayer";
 
 type MetaItem = {
   label: string;
@@ -17,6 +19,11 @@ type MediaDetailShellProps = {
   controls?: ReactNode;
   actions?: ReactNode;
   infoNote?: ReactNode;
+  /** When set, plays Videasy in-page via client-side decode + HLS instead of an iframe. */
+  customPlayer?: {
+    videasyRequest: DownloadRequest;
+    continueWatching?: VideasyCustomPlayerContinueConfig | null;
+  };
 };
 
 export default function MediaDetailShell({
@@ -31,6 +38,7 @@ export default function MediaDetailShell({
   controls,
   actions,
   infoNote,
+  customPlayer,
 }: MediaDetailShellProps) {
   return (
     <div className="detail-shell">
@@ -44,14 +52,23 @@ export default function MediaDetailShell({
         </div>
 
         <div className="movie-player detail-player-frame">
-          <iframe
-            name="framez"
-            id="framez"
-            src={embedUrl}
-            allowFullScreen
-            allow="autoplay; fullscreen; picture-in-picture"
-            className="movie-iframe"
-          />
+          {customPlayer ? (
+            <VideasyCustomPlayer
+              title={title}
+              streamUrl={embedUrl}
+              videasyRequest={customPlayer.videasyRequest}
+              continueWatching={customPlayer.continueWatching ?? null}
+            />
+          ) : (
+            <iframe
+              name="framez"
+              id="framez"
+              src={embedUrl}
+              allowFullScreen
+              allow="autoplay; fullscreen; picture-in-picture"
+              className="movie-iframe"
+            />
+          )}
         </div>
 
         {controls ? <div className="detail-control-grid">{controls}</div> : null}

--- a/components/VideasyCustomPlayer.tsx
+++ b/components/VideasyCustomPlayer.tsx
@@ -1,0 +1,505 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Hls from "hls.js";
+import { fetchVideasyDownloadData, type DownloadRequest } from "../utils/videasyDownloader";
+import {
+  VIDEOASY_SOURCE_UI_LABELS,
+  type StreamQuality,
+  type VideasySourceUiLabel,
+  fetchPlaylistText,
+  isM3u8Url,
+  normalizeVideasyUrl,
+  parseTvSeasonEpisodeFromUrl,
+  pickSourceUrlByUiLabel,
+  selectPlaybackQualityUrl,
+  withResolutionCacheBuster,
+} from "../lib/videasyPlayback";
+
+export type VideasyCustomPlayerContinueConfig = {
+  storageKey: string;
+  indexEntry: string;
+  mode: "movie" | "tv" | "animeMovie" | "animeTv";
+  tmdbId: string;
+  title: string;
+  posterPath?: string | null;
+  seasonNumber?: number;
+  episodeNumber?: number;
+};
+
+type Props = {
+  title: string;
+  streamUrl: string;
+  videasyRequest: DownloadRequest;
+  continueWatching?: VideasyCustomPlayerContinueConfig | null;
+  className?: string;
+};
+
+function readResumeSeconds(
+  storageKey: string,
+  seasonNumber?: number,
+  episodeNumber?: number
+): number {
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) return 0;
+    const parsed = JSON.parse(raw) as {
+      timestamp?: number;
+      seasonNumber?: number;
+      episodeNumber?: number;
+    };
+    if (
+      seasonNumber != null &&
+      episodeNumber != null &&
+      (Number(parsed?.seasonNumber) !== seasonNumber || Number(parsed?.episodeNumber) !== episodeNumber)
+    ) {
+      return 0;
+    }
+    const ts = Math.floor(Number(parsed?.timestamp || 0));
+    return ts > 0 ? ts : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function touchContinueWatchingIndex(indexEntry: string) {
+  try {
+    const indexKey = "continueWatching:index";
+    const indexRaw = window.localStorage.getItem(indexKey);
+    const index: string[] = indexRaw ? JSON.parse(indexRaw) : [];
+    const filtered = index.filter((e) => e !== indexEntry);
+    filtered.unshift(indexEntry);
+    window.localStorage.setItem(indexKey, JSON.stringify(filtered.slice(0, 50)));
+  } catch {
+    // ignore
+  }
+}
+
+function saveContinueProgress(
+  cfg: VideasyCustomPlayerContinueConfig,
+  positionSeconds: number,
+  durationSeconds: number
+) {
+  if (positionSeconds < 10 || durationSeconds <= 0) return;
+
+  const progress = Math.max(0, Math.min(100, (positionSeconds / durationSeconds) * 100));
+  const timestamp = Math.max(0, Math.floor(positionSeconds));
+  const duration = Math.max(0, Math.floor(durationSeconds));
+  const updatedAt = new Date().toISOString();
+
+  try {
+    const existing = window.localStorage.getItem(cfg.storageKey);
+    const parsed = existing ? JSON.parse(existing) : {};
+
+    if (cfg.mode === "movie" || cfg.mode === "animeMovie") {
+      window.localStorage.setItem(
+        cfg.storageKey,
+        JSON.stringify({
+          ...parsed,
+          timestamp,
+          duration,
+          progress,
+          updatedAt,
+          title: cfg.title,
+          posterPath: cfg.posterPath ?? parsed.posterPath,
+          mediaType: cfg.mode === "animeMovie" ? "anime:movie" : "movie",
+          tmdbId: cfg.tmdbId,
+        })
+      );
+      touchContinueWatchingIndex(cfg.indexEntry);
+      return;
+    }
+
+    const seasonNumber = cfg.seasonNumber ?? Number(parsed.seasonNumber) || 1;
+    const episodeNumber = cfg.episodeNumber ?? Number(parsed.episodeNumber) || 1;
+
+    window.localStorage.setItem(
+      cfg.storageKey,
+      JSON.stringify({
+        ...parsed,
+        seasonNumber,
+        episodeNumber,
+        timestamp,
+        duration,
+        progress,
+        updatedAt,
+        title: cfg.title,
+        posterPath: cfg.posterPath ?? parsed.posterPath,
+        mediaType: cfg.mode === "animeTv" ? "anime:tv" : "tv",
+        tmdbId: cfg.tmdbId,
+      })
+    );
+    touchContinueWatchingIndex(cfg.indexEntry);
+  } catch {
+    // ignore
+  }
+}
+
+export default function VideasyCustomPlayer({
+  title,
+  streamUrl,
+  videasyRequest,
+  continueWatching,
+  className = "",
+}: Props) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const hlsRef = useRef<Hls | null>(null);
+  const lastSaveRef = useRef(0);
+  const sourceResolveGen = useRef(0);
+  const playbackGen = useRef(0);
+
+  const [isResolving, setIsResolving] = useState(true);
+  const [playbackError, setPlaybackError] = useState<string | null>(null);
+  const [resolvedLabel, setResolvedLabel] = useState<string>("");
+  const [masterBundle, setMasterBundle] = useState<{ url: string; playlist: string } | null>(null);
+
+  const [selectedSource, setSelectedSource] = useState<VideasySourceUiLabel | string>("Auto");
+  const [sourcesList, setSourcesList] = useState<{ url: string; quality?: string }[]>([]);
+  const [selectedQualityUrl, setSelectedQualityUrl] = useState<string | null>(null);
+  const [selectedQualityLabel, setSelectedQualityLabel] = useState<string | null>(null);
+  const [availableQualities, setAvailableQualities] = useState<StreamQuality[]>([]);
+
+  const [optionsOpen, setOptionsOpen] = useState(false);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const requestKey = useMemo(() => JSON.stringify(videasyRequest), [videasyRequest]);
+
+  const startPosition = useMemo(() => {
+    if (!continueWatching) return 0;
+    return readResumeSeconds(
+      continueWatching.storageKey,
+      continueWatching.seasonNumber,
+      continueWatching.episodeNumber
+    );
+  }, [continueWatching]);
+
+  const teardownHls = useCallback(() => {
+    if (hlsRef.current) {
+      hlsRef.current.destroy();
+      hlsRef.current = null;
+    }
+    const v = videoRef.current;
+    if (v) {
+      try {
+        v.pause();
+        v.removeAttribute("src");
+        v.load();
+      } catch {
+        // ignore
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      teardownHls();
+    };
+  }, [teardownHls]);
+
+  // Resolve Videasy sources and master HLS playlist (client-side WASM + fetch).
+  useEffect(() => {
+    const gen = ++sourceResolveGen.current;
+    setIsResolving(true);
+    setPlaybackError(null);
+    setMasterBundle(null);
+    teardownHls();
+
+    let cancelled = false;
+
+    const run = async () => {
+      try {
+        const decoded = await fetchVideasyDownloadData(JSON.parse(requestKey) as DownloadRequest);
+        if (cancelled || gen !== sourceResolveGen.current) return;
+
+        const list = decoded.sources || [];
+        setSourcesList(list);
+
+        const picked = pickSourceUrlByUiLabel(list, selectedSource);
+        if (!picked) {
+          throw new Error("No stream sources returned.");
+        }
+
+        let masterUrl = picked;
+        if (!isM3u8Url(picked)) {
+          try {
+            masterUrl = withResolutionCacheBuster(normalizeVideasyUrl(picked));
+          } catch {
+            throw new Error(
+              "This source is not a direct HLS manifest. Use the site embed for this provider."
+            );
+          }
+        }
+
+        const playlistText = await fetchPlaylistText(masterUrl);
+        if (cancelled || gen !== sourceResolveGen.current) return;
+
+        const { qualities, effective } = selectPlaybackQualityUrl(
+          masterUrl,
+          playlistText,
+          null,
+          null
+        );
+
+        setAvailableQualities(qualities);
+        setSelectedQualityUrl(effective?.url ?? null);
+        setSelectedQualityLabel(effective?.label ?? null);
+
+        const labelBits = [effective?.label, list[0]?.quality].filter(Boolean);
+        setResolvedLabel(labelBits.join(" · ") || "Stream");
+
+        setMasterBundle({ url: masterUrl, playlist: playlistText });
+      } catch (e: unknown) {
+        if (cancelled || gen !== sourceResolveGen.current) return;
+        setIsResolving(false);
+        setPlaybackError(e instanceof Error ? e.message : String(e));
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [requestKey, reloadToken, streamUrl, selectedSource, teardownHls]);
+
+  // Attach HLS to the selected variant (quality changes do not re-hit Videasy APIs).
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || !masterBundle) return;
+
+    const gen = ++playbackGen.current;
+    setIsResolving(true);
+    setPlaybackError(null);
+    teardownHls();
+
+    let cancelled = false;
+    const resumeAt = startPosition;
+
+    try {
+      const { playbackUrl } = selectPlaybackQualityUrl(
+        masterBundle.url,
+        masterBundle.playlist,
+        selectedQualityUrl,
+        selectedQualityLabel
+      );
+
+      if (!Hls.isSupported()) {
+        if (video.canPlayType("application/vnd.apple.mpegurl")) {
+          video.src = playbackUrl;
+        } else {
+          throw new Error("HLS playback is not supported in this browser.");
+        }
+      } else {
+        const hls = new Hls({
+          enableWorker: true,
+          lowLatencyMode: false,
+        });
+        hlsRef.current = hls;
+        hls.attachMedia(video);
+        hls.loadSource(playbackUrl);
+        hls.on(Hls.Events.ERROR, (_, data) => {
+          if (data.fatal) {
+            setPlaybackError(data.type + (data.details ? `: ${data.details}` : ""));
+          }
+        });
+      }
+
+      const onLoaded = () => {
+        if (cancelled || gen !== playbackGen.current) return;
+        if (resumeAt > 0 && video.duration > 0 && resumeAt < video.duration - 5) {
+          try {
+            video.currentTime = resumeAt;
+          } catch {
+            // ignore
+          }
+        }
+        video.removeEventListener("loadedmetadata", onLoaded);
+      };
+      video.addEventListener("loadedmetadata", onLoaded);
+
+      if (cancelled || gen !== playbackGen.current) return;
+      setIsResolving(false);
+      void video.play().catch(() => {
+        // autoplay may be blocked
+      });
+    } catch (e: unknown) {
+      if (cancelled || gen !== playbackGen.current) return;
+      setIsResolving(false);
+      setPlaybackError(e instanceof Error ? e.message : String(e));
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    masterBundle,
+    selectedQualityUrl,
+    selectedQualityLabel,
+    startPosition,
+    teardownHls,
+  ]);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    const cfg = continueWatching;
+    if (!video || !cfg) return;
+
+    const onTime = () => {
+      const now = Date.now();
+      if (now - lastSaveRef.current < 8000) return;
+      lastSaveRef.current = now;
+      const position = video.currentTime;
+      const duration = video.duration;
+      if (position > 0 && duration > 0) {
+        saveContinueProgress(cfg, position, duration);
+      }
+    };
+
+    video.addEventListener("timeupdate", onTime);
+    return () => video.removeEventListener("timeupdate", onTime);
+  }, [continueWatching]);
+
+  const qualityDropdownValue = useMemo(() => {
+    if (!availableQualities.length) return "auto";
+    if (selectedQualityUrl && availableQualities.some((q) => q.url === selectedQualityUrl)) {
+      return selectedQualityUrl;
+    }
+    if (selectedQualityLabel) {
+      const match = availableQualities.find((q) => q.label === selectedQualityLabel);
+      if (match) return match.url;
+    }
+    return availableQualities[0].url;
+  }, [availableQualities, selectedQualityUrl, selectedQualityLabel]);
+
+  const handleChangeQuality = (value: string) => {
+    if (value === "auto") {
+      setSelectedQualityUrl(null);
+      setSelectedQualityLabel(null);
+    } else {
+      const q = availableQualities.find((x) => x.url === value);
+      setSelectedQualityUrl(value);
+      setSelectedQualityLabel(q?.label ?? null);
+    }
+    setOptionsOpen(false);
+  };
+
+  const handleChangeSource = (value: string) => {
+    setSelectedSource(value);
+    setSelectedQualityUrl(null);
+    setSelectedQualityLabel(null);
+    setOptionsOpen(false);
+  };
+
+  const handleRetry = () => {
+    setPlaybackError(null);
+    setReloadToken((t) => t + 1);
+  };
+
+  const tvFromUrl = parseTvSeasonEpisodeFromUrl(streamUrl);
+
+  return (
+    <div className={`videasy-custom-player ${className}`.trim()}>
+      <div className="videasy-custom-player__chrome">
+        <span className="videasy-custom-player__title" title={title}>
+          {title}
+        </span>
+        <div className="videasy-custom-player__chrome-actions">
+          <button
+            type="button"
+            className="videasy-custom-player__icon-btn"
+            disabled={isResolving}
+            onClick={() => setOptionsOpen((o) => !o)}
+            aria-expanded={optionsOpen}
+          >
+            Options
+          </button>
+        </div>
+      </div>
+
+      <div className="videasy-custom-player__stage">
+        <video ref={videoRef} className="videasy-custom-player__video" controls playsInline />
+
+        {isResolving ? (
+          <div className="videasy-custom-player__overlay videasy-custom-player__overlay--loading">
+            <div className="videasy-custom-player__spinner" />
+            <p>Resolving stream…</p>
+          </div>
+        ) : null}
+
+        {playbackError ? (
+          <div className="videasy-custom-player__overlay videasy-custom-player__overlay--error">
+            <p className="videasy-custom-player__error-title">Unable to play this stream.</p>
+            <p className="videasy-custom-player__error-detail">{playbackError}</p>
+            <button type="button" onClick={handleRetry}>
+              Retry
+            </button>
+          </div>
+        ) : null}
+      </div>
+
+      {!playbackError && !isResolving ? (
+        <p className="videasy-custom-player__meta">{resolvedLabel}</p>
+      ) : null}
+
+      {optionsOpen ? (
+        <div className="videasy-custom-player__sheet-backdrop" role="presentation" onClick={() => setOptionsOpen(false)}>
+          <div
+            className="videasy-custom-player__sheet"
+            role="dialog"
+            aria-label="Playback options"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="videasy-custom-player__sheet-header">
+              <h2>Playback options</h2>
+              <button type="button" className="videasy-custom-player__sheet-close" onClick={() => setOptionsOpen(false)}>
+                Close
+              </button>
+            </div>
+
+            <label className="videasy-custom-player__field">
+              <span>Source</span>
+              <select value={selectedSource} onChange={(e) => handleChangeSource(e.target.value)}>
+                {VIDEOASY_SOURCE_UI_LABELS.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </label>
+            {sourcesList.length ? (
+              <p className="videasy-custom-player__hint">
+                {sourcesList.length} decoded source{sourcesList.length === 1 ? "" : "s"} — labels match Videasy quality
+                names when present.
+              </p>
+            ) : null}
+
+            <label className="videasy-custom-player__field">
+              <span>Quality (HLS variant)</span>
+              <select
+                value={qualityDropdownValue}
+                onChange={(e) => handleChangeQuality(e.target.value)}
+                disabled={!availableQualities.length}
+              >
+                {!availableQualities.length ? <option value="auto">Auto</option> : null}
+                {availableQualities.map((q) => (
+                  <option key={q.url} value={q.url}>
+                    {q.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {tvFromUrl ? (
+              <p className="videasy-custom-player__hint">
+                Episode in URL: S{tvFromUrl.season}E{tvFromUrl.episode}. Use the season and episode selectors on the
+                page to change episode; the player reloads automatically.
+              </p>
+            ) : null}
+
+            <button type="button" className="videasy-custom-player__sheet-done" onClick={() => setOptionsOpen(false)}>
+              Done
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/VideasyCustomPlayer.tsx
+++ b/components/VideasyCustomPlayer.tsx
@@ -11,6 +11,8 @@ import {
   parseTvSeasonEpisodeFromUrl,
   pickSourceUrlByUiLabel,
   selectPlaybackQualityUrl,
+  shouldFallbackToVideasyEmbed,
+  VIDEASY_EMBED_FALLBACK_MESSAGE,
   withResolutionCacheBuster,
 } from "../lib/videasyPlayback";
 
@@ -24,6 +26,109 @@ export type VideasyCustomPlayerContinueConfig = {
   seasonNumber?: number;
   episodeNumber?: number;
 };
+
+function touchContinueWatchingIndex(indexEntry: string) {
+  try {
+    const indexKey = "continueWatching:index";
+    const indexRaw = window.localStorage.getItem(indexKey);
+    const index: string[] = indexRaw ? JSON.parse(indexRaw) : [];
+    const filtered = index.filter((e) => e !== indexEntry);
+    filtered.unshift(indexEntry);
+    window.localStorage.setItem(indexKey, JSON.stringify(filtered.slice(0, 50)));
+  } catch {
+    // ignore
+  }
+}
+
+function expectedVideasyPostMessageType(mode: VideasyCustomPlayerContinueConfig["mode"]): "movie" | "tv" {
+  return mode === "tv" || mode === "animeTv" ? "tv" : "movie";
+}
+
+function applyVideasyEmbedProgressMessage(
+  event: MessageEvent,
+  cfg: VideasyCustomPlayerContinueConfig
+): void {
+  if (event.origin !== "https://player.videasy.net") return;
+
+  const payload =
+    typeof event.data === "string"
+      ? (() => {
+          try {
+            return JSON.parse(event.data) as Record<string, unknown> | null;
+          } catch {
+            return null;
+          }
+        })()
+      : (event.data as Record<string, unknown> | null);
+
+  if (!payload || typeof payload !== "object") return;
+
+  const expectedType = expectedVideasyPostMessageType(cfg.mode);
+  if (payload.type !== expectedType) return;
+  if (String(payload.id) !== cfg.tmdbId) return;
+
+  const timestamp = Math.max(0, Math.floor(Number(payload.timestamp || 0)));
+  const duration = Math.max(0, Math.floor(Number(payload.duration || 0)));
+  const progress = Math.max(0, Math.min(100, Number(payload.progress || 0)));
+
+  try {
+    const existing = window.localStorage.getItem(cfg.storageKey);
+    const parsed = existing ? JSON.parse(existing) : {};
+
+    if (cfg.mode === "movie" || cfg.mode === "animeMovie") {
+      window.localStorage.setItem(
+        cfg.storageKey,
+        JSON.stringify({
+          ...parsed,
+          timestamp,
+          duration,
+          progress,
+          updatedAt: new Date().toISOString(),
+          title: cfg.title,
+          posterPath: cfg.posterPath ?? parsed.posterPath,
+          mediaType: cfg.mode === "animeMovie" ? "anime:movie" : "movie",
+          tmdbId: cfg.tmdbId,
+        })
+      );
+      touchContinueWatchingIndex(cfg.indexEntry);
+      return;
+    }
+
+    const payloadSeason = Number(payload.season);
+    const payloadEpisode = Number(payload.episode);
+    const seasonNumber =
+      Number.isFinite(payloadSeason) && payloadSeason > 0 ? payloadSeason : (cfg.seasonNumber ?? 1);
+    const episodeNumber =
+      Number.isFinite(payloadEpisode) && payloadEpisode > 0 ? payloadEpisode : (cfg.episodeNumber ?? 1);
+
+    window.localStorage.setItem(
+      cfg.storageKey,
+      JSON.stringify({
+        ...parsed,
+        seasonNumber,
+        episodeNumber,
+        timestamp,
+        duration,
+        progress,
+        updatedAt: new Date().toISOString(),
+        title: cfg.title,
+        posterPath: cfg.posterPath ?? parsed.posterPath,
+        mediaType: cfg.mode === "animeTv" ? "anime:tv" : "tv",
+        tmdbId: cfg.tmdbId,
+      })
+    );
+    const track =
+      timestamp > 0 ||
+      progress > 0 ||
+      seasonNumber !== 1 ||
+      episodeNumber !== 1;
+    if (track) {
+      touchContinueWatchingIndex(cfg.indexEntry);
+    }
+  } catch {
+    // ignore
+  }
+}
 
 type Props = {
   title: string;
@@ -57,19 +162,6 @@ function readResumeSeconds(
     return ts > 0 ? ts : 0;
   } catch {
     return 0;
-  }
-}
-
-function touchContinueWatchingIndex(indexEntry: string) {
-  try {
-    const indexKey = "continueWatching:index";
-    const indexRaw = window.localStorage.getItem(indexKey);
-    const index: string[] = indexRaw ? JSON.parse(indexRaw) : [];
-    const filtered = index.filter((e) => e !== indexEntry);
-    filtered.unshift(indexEntry);
-    window.localStorage.setItem(indexKey, JSON.stringify(filtered.slice(0, 50)));
-  } catch {
-    // ignore
   }
 }
 
@@ -159,6 +251,7 @@ export default function VideasyCustomPlayer({
 
   const [optionsOpen, setOptionsOpen] = useState(false);
   const [reloadToken, setReloadToken] = useState(0);
+  const [useEmbedFallback, setUseEmbedFallback] = useState(false);
 
   const requestKey = useMemo(() => JSON.stringify(videasyRequest), [videasyRequest]);
 
@@ -194,12 +287,23 @@ export default function VideasyCustomPlayer({
     };
   }, [teardownHls]);
 
+  useEffect(() => {
+    if (!useEmbedFallback || !continueWatching) return;
+
+    const handler = (event: MessageEvent) => {
+      applyVideasyEmbedProgressMessage(event, continueWatching);
+    };
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, [useEmbedFallback, continueWatching]);
+
   // Resolve Videasy sources and master HLS playlist (client-side WASM + fetch).
   useEffect(() => {
     const gen = ++sourceResolveGen.current;
     setIsResolving(true);
     setPlaybackError(null);
     setMasterBundle(null);
+    setUseEmbedFallback(false);
     teardownHls();
 
     let cancelled = false;
@@ -222,9 +326,7 @@ export default function VideasyCustomPlayer({
           try {
             masterUrl = withResolutionCacheBuster(normalizeVideasyUrl(picked));
           } catch {
-            throw new Error(
-              "This source is not a direct HLS manifest. Use the site embed for this provider."
-            );
+            throw new Error(VIDEASY_EMBED_FALLBACK_MESSAGE);
           }
         }
 
@@ -248,8 +350,15 @@ export default function VideasyCustomPlayer({
         setMasterBundle({ url: masterUrl, playlist: playlistText });
       } catch (e: unknown) {
         if (cancelled || gen !== sourceResolveGen.current) return;
+        if (shouldFallbackToVideasyEmbed(e)) {
+          setUseEmbedFallback(true);
+          setPlaybackError(null);
+          setMasterBundle(null);
+          setResolvedLabel("Videasy embed");
+        } else {
+          setPlaybackError(e instanceof Error ? e.message : String(e));
+        }
         setIsResolving(false);
-        setPlaybackError(e instanceof Error ? e.message : String(e));
       }
     };
 
@@ -390,6 +499,7 @@ export default function VideasyCustomPlayer({
 
   const handleRetry = () => {
     setPlaybackError(null);
+    setUseEmbedFallback(false);
     setReloadToken((t) => t + 1);
   };
 
@@ -411,11 +521,26 @@ export default function VideasyCustomPlayer({
           >
             Options
           </button>
+          {useEmbedFallback ? (
+            <button type="button" className="videasy-custom-player__icon-btn" onClick={handleRetry}>
+              Retry HLS
+            </button>
+          ) : null}
         </div>
       </div>
 
       <div className="videasy-custom-player__stage">
-        <video ref={videoRef} className="videasy-custom-player__video" controls playsInline />
+        {useEmbedFallback ? (
+          <iframe
+            title={title}
+            src={streamUrl}
+            allowFullScreen
+            allow="autoplay; fullscreen; picture-in-picture"
+            className="videasy-custom-player__embed"
+          />
+        ) : (
+          <video ref={videoRef} className="videasy-custom-player__video" controls playsInline />
+        )}
 
         {isResolving ? (
           <div className="videasy-custom-player__overlay videasy-custom-player__overlay--loading">
@@ -436,7 +561,9 @@ export default function VideasyCustomPlayer({
       </div>
 
       {!playbackError && !isResolving ? (
-        <p className="videasy-custom-player__meta">{resolvedLabel}</p>
+        <p className="videasy-custom-player__meta">
+          {useEmbedFallback ? "Playing in Videasy embed (decoded URL was not direct HLS)." : resolvedLabel}
+        </p>
       ) : null}
 
       {optionsOpen ? (
@@ -456,7 +583,11 @@ export default function VideasyCustomPlayer({
 
             <label className="videasy-custom-player__field">
               <span>Source</span>
-              <select value={selectedSource} onChange={(e) => handleChangeSource(e.target.value)}>
+              <select
+                value={selectedSource}
+                onChange={(e) => handleChangeSource(e.target.value)}
+                disabled={useEmbedFallback}
+              >
                 {VIDEOASY_SOURCE_UI_LABELS.map((s) => (
                   <option key={s} value={s}>
                     {s}
@@ -476,7 +607,7 @@ export default function VideasyCustomPlayer({
               <select
                 value={qualityDropdownValue}
                 onChange={(e) => handleChangeQuality(e.target.value)}
-                disabled={!availableQualities.length}
+                disabled={!availableQualities.length || useEmbedFallback}
               >
                 {!availableQualities.length ? <option value="auto">Auto</option> : null}
                 {availableQualities.map((q) => (

--- a/components/VideasyCustomPlayer.tsx
+++ b/components/VideasyCustomPlayer.tsx
@@ -108,8 +108,8 @@ function saveContinueProgress(
       return;
     }
 
-    const seasonNumber = cfg.seasonNumber ?? Number(parsed.seasonNumber) || 1;
-    const episodeNumber = cfg.episodeNumber ?? Number(parsed.episodeNumber) || 1;
+    const seasonNumber = cfg.seasonNumber ?? (Number(parsed.seasonNumber) || 1);
+    const episodeNumber = cfg.episodeNumber ?? (Number(parsed.episodeNumber) || 1);
 
     window.localStorage.setItem(
       cfg.storageKey,

--- a/lib/videasyPlayback.ts
+++ b/lib/videasyPlayback.ts
@@ -1,0 +1,191 @@
+/** Client-side Videasy URL and HLS helpers (aligned with authorized_playback_screen.dart). */
+
+export const VIDEOASY_SOURCE_UI_LABELS = [
+  "Auto",
+  "Neon",
+  "Yoru",
+  "Cypher",
+  "Sage",
+  "Jett",
+  "Reyna",
+  "Breach",
+  "Vyse",
+] as const;
+
+export type VideasySourceUiLabel = (typeof VIDEOASY_SOURCE_UI_LABELS)[number];
+
+export type StreamQuality = {
+  label: string;
+  url: string;
+  bandwidth: number;
+};
+
+export function isM3u8Url(value: string): boolean {
+  const uri = new URL(value, "https://player.videasy.net/");
+  const hay = `${uri.pathname}${uri.search}`;
+  return /\.m3u8(?:[?#]|$)/i.test(hay);
+}
+
+export function normalizeVideasyUrl(input: string): string {
+  const trimmed = input.trim();
+  const uri = new URL(trimmed);
+  if (uri.protocol !== "https:") {
+    throw new Error("Only HTTPS Videasy links are supported.");
+  }
+
+  if (isM3u8Url(trimmed)) {
+    return uri.href.split("#")[0];
+  }
+
+  const host = uri.hostname.toLowerCase();
+  if (host !== "player.videasy.net" && host !== "videasy.net" && host !== "www.videasy.net") {
+    throw new Error(`Unsupported Videasy host: ${uri.host}.`);
+  }
+
+  if (host === "videasy.net" || host === "www.videasy.net") {
+    const path = uri.pathname.replace(/^\/+/, "");
+    if (!path.startsWith("movie/") && !path.startsWith("tv/")) {
+      throw new Error("Videasy links must start with /movie/... or /tv/...");
+    }
+    const next = new URL(`https://player.videasy.net/${path}`);
+    uri.searchParams.forEach((v, k) => next.searchParams.set(k, v));
+    return next.href.split("#")[0];
+  }
+
+  if (
+    !uri.pathname.startsWith("/movie/") &&
+    !uri.pathname.startsWith("/tv/") &&
+    !uri.pathname.startsWith("/anime/")
+  ) {
+    throw new Error("Unsupported Videasy player path.");
+  }
+
+  return uri.href.split("#")[0];
+}
+
+export function withResolutionCacheBuster(value: string): string {
+  if (isM3u8Url(value)) {
+    return value;
+  }
+  const uri = new URL(value);
+  uri.searchParams.set("_impactstreamResolve", String(Date.now() * 1000 + Math.floor(Math.random() * 1000)));
+  return uri.toString();
+}
+
+export function parseTvSeasonEpisodeFromUrl(streamUrl: string): { season: number; episode: number } | null {
+  const match = streamUrl.match(/\/tv\/\d+\/(\d+)\/(\d+)/);
+  if (!match) return null;
+  const season = Number(match[1]);
+  const episode = Number(match[2]);
+  if (!Number.isFinite(season) || season < 1 || !Number.isFinite(episode) || episode < 1) return null;
+  return { season, episode };
+}
+
+function findQuality(
+  qualities: StreamQuality[],
+  test: (q: StreamQuality) => boolean
+): StreamQuality | null {
+  for (const q of qualities) {
+    if (test(q)) return q;
+  }
+  return null;
+}
+
+export function parseMasterPlaylistQualities(playlist: string, baseUrl: string): StreamQuality[] {
+  const lines = playlist.split(/\r?\n/);
+  const qualities: StreamQuality[] = [];
+  const base = new URL(baseUrl);
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i].trim();
+    if (!line.startsWith("#EXT-X-STREAM-INF")) continue;
+
+    const bandwidth = Number(RegExp(/BANDWIDTH=(\d+)/).exec(line)?.[1] || 0) || 0;
+    const resolution = RegExp(/RESOLUTION=(\d+x\d+)/).exec(line)?.[1];
+    let uriMatch = RegExp(/URI="([^"]+)"/).exec(line)?.[1];
+    let child: string | undefined = uriMatch;
+
+    if (child == null) {
+      for (let j = i + 1; j < lines.length; j += 1) {
+        const next = lines[j].trim();
+        if (next === "") continue;
+        if (next.startsWith("#")) break;
+        child = next;
+        break;
+      }
+    }
+
+    if (child == null) continue;
+
+    const label =
+      resolution != null
+        ? `${resolution.split("x").pop()}p`
+        : bandwidth > 0
+          ? `${(bandwidth / 1_000_000).toFixed(1)} Mbps`
+          : `Variant ${qualities.length + 1}`;
+
+    qualities.push({
+      label,
+      url: new URL(child, base).href.split("#")[0],
+      bandwidth,
+    });
+  }
+
+  qualities.sort((a, b) => b.bandwidth - a.bandwidth);
+  const seenLabels: Record<string, number> = {};
+  return qualities.map((quality) => {
+    const count = (seenLabels[quality.label] ?? 0) + 1;
+    seenLabels[quality.label] = count;
+    if (count === 1) return quality;
+    return { ...quality, label: `${quality.label} #${count}` };
+  });
+}
+
+export async function fetchPlaylistText(url: string): Promise<string> {
+  const res = await fetch(url, {
+    headers: {
+      Accept: "*/*",
+      Origin: "https://player.videasy.net",
+      Referer: "https://player.videasy.net/",
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Playlist request failed with ${res.status}.`);
+  }
+  const text = await res.text();
+  const body = text.trimStart();
+  if (!body.startsWith("#EXTM3U")) {
+    throw new Error(`Expected an HLS playlist from ${url}.`);
+  }
+  return text;
+}
+
+export function selectPlaybackQualityUrl(
+  m3u8Url: string,
+  playlistText: string,
+  selectedQualityUrl: string | null,
+  selectedQualityLabel: string | null
+): { playbackUrl: string; qualities: StreamQuality[]; effective: StreamQuality | null } {
+  const qualities = parseMasterPlaylistQualities(playlistText, m3u8Url);
+  const byUrl = selectedQualityUrl
+    ? findQuality(qualities, (q) => q.url === selectedQualityUrl)
+    : null;
+  const byLabel = selectedQualityLabel
+    ? findQuality(qualities, (q) => q.label === selectedQualityLabel)
+    : null;
+  const effective = byUrl ?? byLabel ?? (qualities.length ? qualities[0] : null);
+  const playbackUrl = effective?.url ?? m3u8Url;
+  return { playbackUrl, qualities, effective };
+}
+
+export function pickSourceUrlByUiLabel(
+  sources: { url: string; quality?: string }[],
+  label: VideasySourceUiLabel | string
+): string | null {
+  if (!sources.length) return null;
+  if (label === "Auto") return sources[0].url;
+
+  const needle = String(label).toLowerCase();
+  const byName = sources.find((s) => (s.quality || "").toLowerCase().includes(needle));
+  return (byName ?? sources[0]).url;
+}

--- a/lib/videasyPlayback.ts
+++ b/lib/videasyPlayback.ts
@@ -1,5 +1,17 @@
 /** Client-side Videasy URL and HLS helpers (aligned with authorized_playback_screen.dart). */
 
+/** Decoded URL is not direct HLS and not a normalizable Videasy player URL — use iframe fallback. */
+export const VIDEASY_EMBED_FALLBACK_MESSAGE =
+  "This source is not a direct HLS manifest. Use the site embed for this provider.";
+
+export function shouldFallbackToVideasyEmbed(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  if (msg === VIDEASY_EMBED_FALLBACK_MESSAGE) return true;
+  // Decoded URL opened in fetch but returned non-playlist (e.g. HTML shell).
+  if (msg.includes("Expected an HLS playlist")) return true;
+  return false;
+}
+
 export const VIDEOASY_SOURCE_UI_LABELS = [
   "Auto",
   "Neon",

--- a/pages/anime/[id].tsx
+++ b/pages/anime/[id].tsx
@@ -225,78 +225,6 @@ export default function AnimeDetailsPage() {
     const storageId = Array.isArray(id) ? id[0] : id;
     const storageKey = `continue:anime:${animeType}:${storageId}`;
 
-    const handleProgressMessage = (event: MessageEvent) => {
-      if (event.origin !== "https://player.videasy.net") return;
-
-      const payload =
-        typeof event.data === "string"
-          ? (() => {
-              try {
-                return JSON.parse(event.data);
-              } catch {
-                return null;
-              }
-            })()
-          : event.data;
-
-      if (!payload || payload.type !== animeType) return;
-      if (String(payload.id) !== storageId) return;
-
-      const payloadSeason = Number(payload.season);
-      const payloadEpisode = Number(payload.episode);
-      if (animeType === "tv" && payloadSeason > 0 && payloadEpisode > 0) {
-        if (payloadSeason !== seasonNumber) {
-          setSeasonNumber(payloadSeason);
-        }
-        if (payloadEpisode !== episodeNumber) {
-          setEpisodeNumber(payloadEpisode);
-        }
-      }
-
-      const timestamp = Math.max(0, Math.floor(Number(payload.timestamp || 0)));
-      const duration = Math.max(0, Math.floor(Number(payload.duration || 0)));
-      const progress = Math.max(0, Math.min(100, Number(payload.progress || 0)));
-      const nextSeason = animeType === "tv" && payloadSeason > 0 ? payloadSeason : 1;
-      const nextEpisode = animeType === "tv" && payloadEpisode > 0 ? payloadEpisode : 1;
-      const nextData = {
-        seasonNumber: nextSeason,
-        episodeNumber: nextEpisode,
-        timestamp,
-        duration,
-        progress,
-        updatedAt: new Date().toISOString(),
-        title: anime?.title || anime?.name || undefined,
-        posterPath: anime?.poster_path || undefined,
-        mediaType: `anime:${animeType}`,
-        tmdbId: storageId,
-      };
-
-      window.localStorage.setItem(
-        storageKey,
-        JSON.stringify(nextData)
-      );
-
-      const indexKey = "continueWatching:index";
-      const indexRaw = window.localStorage.getItem(indexKey);
-      const index: string[] = indexRaw ? JSON.parse(indexRaw) : [];
-      const entry = `anime:${animeType}:${storageId}`;
-      const filtered = index.filter((e) => e !== entry);
-      if (animeType === "movie" || shouldTrackContinueWatching(nextData)) {
-        filtered.unshift(entry);
-      }
-      window.localStorage.setItem(indexKey, JSON.stringify(filtered.slice(0, 50)));
-    };
-
-    window.addEventListener("message", handleProgressMessage);
-    return () => window.removeEventListener("message", handleProgressMessage);
-  }, [id, animeType, isProgressLoaded, seasonNumber, episodeNumber, anime]);
-
-  useEffect(() => {
-    if (!id || !isProgressLoaded) return;
-
-    const storageId = Array.isArray(id) ? id[0] : id;
-    const storageKey = `continue:anime:${animeType}:${storageId}`;
-
     try {
       const stored = window.localStorage.getItem(storageKey);
       if (!stored) {
@@ -328,19 +256,10 @@ export default function AnimeDetailsPage() {
     setSeasonNumber(value);
   };
 
-  const title = anime?.title || anime?.name || "Untitled";
-  const releaseDate = anime?.release_date || anime?.first_air_date || "Unknown";
-  const runtime = anime?.runtime || anime?.episode_run_time?.[0];
-  const posterUrl = anime?.poster_path
-    ? `https://image.tmdb.org/t/p/w500${anime.poster_path}`
-    : "/no-image.svg";
-  const backdropUrl = anime?.backdrop_path
-    ? `https://image.tmdb.org/t/p/original${anime.backdrop_path}`
-    : undefined;
+  const mediaId = id ? (Array.isArray(id) ? id[0] : id) : "";
 
   const streamUrl = useMemo(() => {
-    if (!id) return "";
-    const mediaId = Array.isArray(id) ? id[0] : id;
+    if (!mediaId) return "";
 
     if (animeType === "movie") {
       const query = new URLSearchParams({
@@ -367,7 +286,58 @@ export default function AnimeDetailsPage() {
       query.set("progress", String(resumeSeconds));
     }
     return `https://player.videasy.net/tv/${mediaId}/${seasonNumber}/${episodeNumber}?${query.toString()}`;
-  }, [id, animeType, seasonNumber, episodeNumber, resumeSeconds]);
+  }, [mediaId, animeType, seasonNumber, episodeNumber, resumeSeconds]);
+
+  const customPlayer = useMemo(() => {
+    if (!anime || !mediaId) return undefined;
+    const tmdbId = Number(mediaId);
+    if (!Number.isFinite(tmdbId) || tmdbId <= 0) return undefined;
+
+    if (animeType === "movie") {
+      return {
+        videasyRequest: {
+          tmdbId,
+          mediaType: "movie" as const,
+          title: anime.title || anime.name || "Untitled",
+          year: String(anime.release_date || anime.first_air_date || "").slice(0, 4),
+          imdbId: anime.external_ids?.imdb_id || anime.imdb_id || "",
+        },
+        continueWatching: {
+          storageKey: `continue:anime:movie:${mediaId}`,
+          indexEntry: `anime:movie:${mediaId}`,
+          mode: "animeMovie" as const,
+          tmdbId: String(mediaId),
+          title: anime.title || anime.name || "Untitled",
+          posterPath: anime.poster_path || null,
+        },
+      };
+    }
+
+    if (seasonNumber <= 0 || episodeNumber <= 0) return undefined;
+
+    return {
+      videasyRequest: {
+        tmdbId,
+        mediaType: "tv" as const,
+        title: anime.title || anime.name || "Untitled",
+        year: String(anime.first_air_date || anime.release_date || "").slice(0, 4),
+        seasonId: seasonNumber,
+        episodeId: episodeNumber,
+        totalSeasons: Number(anime.number_of_seasons || 0),
+        imdbId: anime.external_ids?.imdb_id || anime.imdb_id || "",
+      },
+      continueWatching: {
+        storageKey: `continue:anime:tv:${mediaId}`,
+        indexEntry: `anime:tv:${mediaId}`,
+        mode: "animeTv" as const,
+        tmdbId: String(mediaId),
+        title: anime.title || anime.name || "Untitled",
+        posterPath: anime.poster_path || null,
+        seasonNumber,
+        episodeNumber,
+      },
+    };
+  }, [anime, mediaId, animeType, seasonNumber, episodeNumber]);
 
   const metadata = useMemo(() => {
     const base = [
@@ -399,6 +369,16 @@ export default function AnimeDetailsPage() {
   );
 
   if (!anime) return <div className="loading">Loading...</div>;
+
+  const title = anime.title || anime.name || "Untitled";
+  const releaseDate = anime.release_date || anime.first_air_date || "Unknown";
+  const runtime = anime.runtime || anime.episode_run_time?.[0];
+  const posterUrl = anime.poster_path
+    ? `https://image.tmdb.org/t/p/w500${anime.poster_path}`
+    : "/no-image.svg";
+  const backdropUrl = anime.backdrop_path
+    ? `https://image.tmdb.org/t/p/original${anime.backdrop_path}`
+    : undefined;
 
   const handleDownload = async () => {
     const tmdbId = Number(Array.isArray(id) ? id[0] : id);
@@ -444,6 +424,7 @@ export default function AnimeDetailsPage() {
         title={title}
         summary={anime.overview || "No overview is available for this anime yet."}
         embedUrl={streamUrl}
+        customPlayer={customPlayer}
         posterUrl={posterUrl}
         backdropUrl={backdropUrl}
         metadata={metadata}

--- a/pages/anime/[id].tsx
+++ b/pages/anime/[id].tsx
@@ -339,6 +339,9 @@ export default function AnimeDetailsPage() {
     };
   }, [anime, mediaId, animeType, seasonNumber, episodeNumber]);
 
+  const releaseDate = anime?.release_date || anime?.first_air_date || "Unknown";
+  const runtime = anime?.runtime || anime?.episode_run_time?.[0];
+
   const metadata = useMemo(() => {
     const base = [
       { label: "Release", value: releaseDate },
@@ -371,8 +374,6 @@ export default function AnimeDetailsPage() {
   if (!anime) return <div className="loading">Loading...</div>;
 
   const title = anime.title || anime.name || "Untitled";
-  const releaseDate = anime.release_date || anime.first_air_date || "Unknown";
-  const runtime = anime.runtime || anime.episode_run_time?.[0];
   const posterUrl = anime.poster_path
     ? `https://image.tmdb.org/t/p/w500${anime.poster_path}`
     : "/no-image.svg";

--- a/pages/movie/[id].tsx
+++ b/pages/movie/[id].tsx
@@ -54,52 +54,6 @@ export default function MovieDetailsPage() {
   useEffect(() => {
     if (!id) return;
 
-    const storageId = Array.isArray(id) ? id[0] : id;
-    const storageKey = `continue:movie:${storageId}`;
-
-    const handleProgressMessage = (event: MessageEvent) => {
-      if (event.origin !== "https://player.videasy.net") return;
-
-      const payload =
-        typeof event.data === "string"
-          ? (() => {
-              try {
-                return JSON.parse(event.data);
-              } catch {
-                return null;
-              }
-            })()
-          : event.data;
-
-      if (!payload || payload.type !== "movie") return;
-      if (String(payload.id) !== storageId) return;
-
-      const timestamp = Math.max(0, Math.floor(Number(payload.timestamp || 0)));
-      const duration = Math.max(0, Math.floor(Number(payload.duration || 0)));
-      const progress = Math.max(0, Math.min(100, Number(payload.progress || 0)));
-
-      window.localStorage.setItem(
-        storageKey,
-        JSON.stringify({
-          timestamp,
-          duration,
-          progress,
-          updatedAt: new Date().toISOString(),
-          title: movie?.title || undefined,
-          posterPath: movie?.poster_path || undefined,
-          mediaType: "movie",
-          tmdbId: storageId,
-        })
-      );
-    };
-
-    window.addEventListener("message", handleProgressMessage);
-    return () => window.removeEventListener("message", handleProgressMessage);
-  }, [id, movie]);
-
-  useEffect(() => {
-    if (!id) return;
-
     const fetchDetails = async () => {
       const { data } = await axios.get(`https://api.themoviedb.org/3/movie/${id}`, {
         params: {
@@ -145,7 +99,47 @@ export default function MovieDetailsPage() {
     }
   }, [id, movie]);
 
-  const title = movie?.title || "Untitled";
+  const movieId = id ? (Array.isArray(id) ? id[0] : id) : "";
+
+  const movieQuery = useMemo(() => {
+    const q = new URLSearchParams({
+      color: "e50914",
+      nextEpisode: "true",
+      episodeSelector: "true",
+      overlay: "true",
+    });
+    if (resumeSeconds > 0) {
+      q.set("progress", String(resumeSeconds));
+    }
+    return q;
+  }, [resumeSeconds]);
+
+  const embedUrl =
+    movieId ? `https://player.videasy.net/movie/${movieId}?${movieQuery.toString()}` : "";
+
+  const customPlayer = useMemo(() => {
+    if (!movie || !movieId) return undefined;
+    const tmdbId = Number(movieId);
+    if (!Number.isFinite(tmdbId) || tmdbId <= 0) return undefined;
+    return {
+      videasyRequest: {
+        tmdbId,
+        mediaType: "movie" as const,
+        title: movie.title || "Untitled",
+        year: (movie.release_date || "").slice(0, 4),
+        imdbId: movie.imdb_id || "",
+      },
+      continueWatching: {
+        storageKey: `continue:movie:${movieId}`,
+        indexEntry: `movie:${movieId}`,
+        mode: "movie" as const,
+        tmdbId: String(movieId),
+        title: movie.title || "Untitled",
+        posterPath: movie.poster_path || null,
+      },
+    };
+  }, [movie, movieId]);
+
   const releaseDate = movie?.release_date || "Unknown";
   const posterUrl = movie?.poster_path
     ? `https://image.tmdb.org/t/p/w500${movie.poster_path}`
@@ -168,28 +162,16 @@ export default function MovieDetailsPage() {
     [movie?.genres]
   );
 
-  if (!movie) return <div className="loading">Loading...</div>;
-
-  const movieId = Array.isArray(id) ? id[0] : id;
-  const movieQuery = new URLSearchParams({
-    color: "e50914",
-    nextEpisode: "true",
-    episodeSelector: "true",
-    overlay: "true",
-  });
-  if (resumeSeconds > 0) {
-    movieQuery.set("progress", String(resumeSeconds));
-  }
-
   const handleDownload = async () => {
     const tmdbId = Number(Array.isArray(id) ? id[0] : id);
-    if (!tmdbId) return;
+    if (!tmdbId || !movie) return;
 
     try {
       setIsDownloading(true);
       setDownloadError("");
 
       const year = (movie.release_date || "").slice(0, 4);
+      const title = movie.title || "Untitled";
       const decoded = await fetchVideasyDownloadData({
         tmdbId,
         mediaType: "movie",
@@ -210,13 +192,18 @@ export default function MovieDetailsPage() {
     }
   };
 
+  if (!movie) return <div className="loading">Loading...</div>;
+
+  const title = movie.title || "Untitled";
+
   return (
     <>
       <MediaDetailShell
         mediaLabel="Movie"
         title={title}
         summary={movie.overview || "No overview is available for this title yet."}
-        embedUrl={`https://player.videasy.net/movie/${movieId}?${movieQuery.toString()}`}
+        embedUrl={embedUrl}
+        customPlayer={customPlayer}
         posterUrl={posterUrl}
         backdropUrl={backdropUrl}
         metadata={metadata}

--- a/pages/tv/[id].tsx
+++ b/pages/tv/[id].tsx
@@ -206,78 +206,6 @@ export default function TVDetailsPage() {
     const storageId = Array.isArray(id) ? id[0] : id;
     const storageKey = `continue:tv:${storageId}`;
 
-    const handleProgressMessage = (event: MessageEvent) => {
-      if (event.origin !== "https://player.videasy.net") return;
-
-      const payload =
-        typeof event.data === "string"
-          ? (() => {
-              try {
-                return JSON.parse(event.data);
-              } catch {
-                return null;
-              }
-            })()
-          : event.data;
-
-      if (!payload || payload.type !== "tv") return;
-      if (String(payload.id) !== storageId) return;
-
-      const payloadSeason = Number(payload.season);
-      const payloadEpisode = Number(payload.episode);
-      if (payloadSeason > 0 && payloadEpisode > 0) {
-        if (payloadSeason !== seasonNumber) {
-          setSeasonNumber(payloadSeason);
-        }
-        if (payloadEpisode !== episodeNumber) {
-          setEpisodeNumber(payloadEpisode);
-        }
-      }
-
-      const timestamp = Math.max(0, Math.floor(Number(payload.timestamp || 0)));
-      const duration = Math.max(0, Math.floor(Number(payload.duration || 0)));
-      const progress = Math.max(0, Math.min(100, Number(payload.progress || 0)));
-      const nextSeason = payloadSeason > 0 ? payloadSeason : seasonNumber;
-      const nextEpisode = payloadEpisode > 0 ? payloadEpisode : episodeNumber;
-      const nextData = {
-        seasonNumber: nextSeason,
-        episodeNumber: nextEpisode,
-        timestamp,
-        duration,
-        progress,
-        updatedAt: new Date().toISOString(),
-        title: tvShow?.name || undefined,
-        posterPath: tvShow?.poster_path || undefined,
-        mediaType: "tv",
-        tmdbId: storageId,
-      };
-
-      window.localStorage.setItem(
-        storageKey,
-        JSON.stringify(nextData)
-      );
-
-      const indexKey = "continueWatching:index";
-      const indexRaw = window.localStorage.getItem(indexKey);
-      const index: string[] = indexRaw ? JSON.parse(indexRaw) : [];
-      const entry = `tv:${storageId}`;
-      const filtered = index.filter((e) => e !== entry);
-      if (shouldTrackContinueWatching(nextData)) {
-        filtered.unshift(entry);
-      }
-      window.localStorage.setItem(indexKey, JSON.stringify(filtered.slice(0, 50)));
-    };
-
-    window.addEventListener("message", handleProgressMessage);
-    return () => window.removeEventListener("message", handleProgressMessage);
-  }, [id, isProgressLoaded, seasonNumber, episodeNumber, tvShow]);
-
-  useEffect(() => {
-    if (!id || !isProgressLoaded || seasonNumber <= 0 || episodeNumber <= 0) return;
-
-    const storageId = Array.isArray(id) ? id[0] : id;
-    const storageKey = `continue:tv:${storageId}`;
-
     try {
       const stored = window.localStorage.getItem(storageKey);
       if (!stored) {
@@ -306,7 +234,54 @@ export default function TVDetailsPage() {
     setSeasonNumber(value);
   };
 
-  const title = tvShow?.name || "Untitled";
+  const tvId = id ? (Array.isArray(id) ? id[0] : id) : "";
+
+  const tvQuery = useMemo(() => {
+    const q = new URLSearchParams({
+      color: "e50914",
+      autoplay: "true",
+      nextEpisode: "true",
+      autoplayNextEpisode: "true",
+      overlay: "true",
+    });
+    if (resumeSeconds > 0) {
+      q.set("progress", String(resumeSeconds));
+    }
+    return q;
+  }, [resumeSeconds]);
+
+  const embedUrl =
+    tvId && seasonNumber > 0 && episodeNumber > 0
+      ? `https://player.videasy.net/tv/${tvId}/${seasonNumber}/${episodeNumber}?${tvQuery.toString()}`
+      : "";
+
+  const customPlayer = useMemo(() => {
+    if (!tvShow || !tvId || seasonNumber <= 0 || episodeNumber <= 0) return undefined;
+    const tmdbId = Number(tvId);
+    if (!Number.isFinite(tmdbId) || tmdbId <= 0) return undefined;
+    return {
+      videasyRequest: {
+        tmdbId,
+        mediaType: "tv" as const,
+        title: tvShow.name || "Untitled",
+        year: (tvShow.first_air_date || "").slice(0, 4),
+        seasonId: seasonNumber,
+        episodeId: episodeNumber,
+        totalSeasons: Number(tvShow.number_of_seasons || 0),
+      },
+      continueWatching: {
+        storageKey: `continue:tv:${tvId}`,
+        indexEntry: `tv:${tvId}`,
+        mode: "tv" as const,
+        tmdbId: String(tvId),
+        title: tvShow.name || "Untitled",
+        posterPath: tvShow.poster_path || null,
+        seasonNumber,
+        episodeNumber,
+      },
+    };
+  }, [tvShow, tvId, seasonNumber, episodeNumber]);
+
   const releaseDate = tvShow?.first_air_date || "Unknown";
   const posterUrl = tvShow?.poster_path
     ? `https://image.tmdb.org/t/p/w500${tvShow.poster_path}`
@@ -331,17 +306,8 @@ export default function TVDetailsPage() {
   );
 
   if (!tvShow) return <div className="loading">Loading...</div>;
-  const tvId = Array.isArray(id) ? id[0] : id;
-  const tvQuery = new URLSearchParams({
-    color: "e50914",
-    autoplay: "true",
-    nextEpisode: "true",
-    autoplayNextEpisode: "true",
-    overlay: "true",
-  });
-  if (resumeSeconds > 0) {
-    tvQuery.set("progress", String(resumeSeconds));
-  }
+
+  const title = tvShow.name || "Untitled";
 
   const handleDownload = async () => {
     const tmdbId = Number(Array.isArray(id) ? id[0] : id);
@@ -383,7 +349,8 @@ export default function TVDetailsPage() {
         mediaLabel="Series"
         title={title}
         summary={tvShow.overview || "No overview is available for this series yet."}
-        embedUrl={`https://player.videasy.net/tv/${tvId}/${seasonNumber}/${episodeNumber}?${tvQuery.toString()}`}
+        embedUrl={embedUrl}
+        customPlayer={customPlayer}
         posterUrl={posterUrl}
         backdropUrl={backdropUrl}
         metadata={metadata}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3442,3 +3442,194 @@ button:active {
     grid-template-columns: 1fr;
   }
 }
+
+/* Client-side Videasy HLS player (replaces iframe on detail pages) */
+.videasy-custom-player {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+  background: #000;
+  border-radius: inherit;
+  overflow: hidden;
+}
+
+.videasy-custom-player__chrome {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.55rem 0.75rem;
+  background: rgba(15, 23, 42, 0.95);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.videasy-custom-player__title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #f1f5f9;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.videasy-custom-player__icon-btn {
+  padding: 0.45rem 0.85rem;
+  font-size: 0.8rem;
+  border-radius: 10px;
+  min-width: auto;
+  box-shadow: none;
+}
+
+.videasy-custom-player__icon-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.videasy-custom-player__stage {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  background: #000;
+}
+
+.videasy-custom-player__video {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: contain;
+  vertical-align: middle;
+}
+
+.videasy-custom-player__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  text-align: center;
+  padding: 1rem;
+}
+
+.videasy-custom-player__overlay--loading {
+  background: rgba(0, 0, 0, 0.75);
+  color: #e2e8f0;
+  font-size: 0.9rem;
+}
+
+.videasy-custom-player__overlay--error {
+  background: rgba(0, 0, 0, 0.88);
+}
+
+.videasy-custom-player__error-title {
+  font-weight: 700;
+  color: #f8fafc;
+  margin: 0;
+}
+
+.videasy-custom-player__error-detail {
+  color: #94a3b8;
+  font-size: 0.85rem;
+  max-width: 28rem;
+  margin: 0;
+}
+
+.videasy-custom-player__spinner {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 255, 255, 0.15);
+  border-top-color: #e50914;
+  animation: videasy-spin 0.85s linear infinite;
+}
+
+@keyframes videasy-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.videasy-custom-player__meta {
+  font-size: 0.78rem;
+  color: #94a3b8;
+  padding: 0 0.75rem 0.5rem;
+  margin: 0;
+}
+
+.videasy-custom-player__sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.videasy-custom-player__sheet {
+  width: 100%;
+  max-width: 480px;
+  max-height: 85vh;
+  overflow-y: auto;
+  background: #10161f;
+  border-radius: 16px 16px 0 0;
+  padding: 1rem 1.1rem 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.videasy-custom-player__sheet-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.videasy-custom-player__sheet-header h2 {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.videasy-custom-player__sheet-close {
+  min-width: auto;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.8rem;
+  box-shadow: none;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.videasy-custom-player__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 0.85rem;
+}
+
+.videasy-custom-player__field span {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+}
+
+.videasy-custom-player__field select {
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  color: #f1f5f9;
+  padding: 0.65rem 0.75rem;
+  font-size: 0.9rem;
+}
+
+.videasy-custom-player__hint {
+  font-size: 0.78rem;
+  color: #64748b;
+  margin: -0.25rem 0 0.75rem;
+  line-height: 1.45;
+}
+
+.videasy-custom-player__sheet-done {
+  width: 100%;
+  margin-top: 0.5rem;
+  box-shadow: none;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3500,6 +3500,14 @@ button:active {
   vertical-align: middle;
 }
 
+.videasy-custom-player__embed {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+  background: #000;
+}
+
 .videasy-custom-player__overlay {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements an in-app **Videasy custom player** in TypeScript/React, modeled on `authorized_playback_screen.dart.txt`: decode sources in the browser, normalize Videasy URLs, fetch the master `.m3u8`, parse `#EXT-X-STREAM-INF` variants for a quality picker, and play HLS with **hls.js**. Watch progress is written to the same **localStorage** keys used by the old iframe `postMessage` flow (those listeners were removed from movie/TV/anime pages).

## Notes

- **Cross-origin**: A plain site iframe cannot inject the Dart WebView capture script into `player.videasy.net`. Resolution uses the existing **`fetchVideasyDownloadData` + WASM** path (same as downloads) instead of intercepting network calls inside the embed.
- **Direct HLS only**: If decoded sources are not `.m3u8` and are not normalizable Videasy player URLs, the player shows a clear error (embed would still work if we passed `customPlayer` only when appropriate; today we always use custom player on these three pages).

## Files

- `lib/videasyPlayback.ts` — URL helpers + master playlist quality parsing (Dart-aligned).
- `components/VideasyCustomPlayer.tsx` — resolve → attach HLS → options sheet (source / quality) → continue watching.
- `components/MediaDetailShell.tsx` — optional `customPlayer` replaces iframe.
- `pages/movie/[id].tsx`, `pages/tv/[id].tsx`, `pages/anime/[id].tsx` — wire `customPlayer`; remove iframe progress handlers; anime continue keys aligned to `continue:anime:movie:` / `continue:anime:tv:`.
- `styles/globals.css` — player + sheet styles.

## Build fixes

- Parenthesize `??` with `||` in `saveContinueProgress` (`VideasyCustomPlayer.tsx`) for TypeScript mixed-operator rules.
- Move `releaseDate` / `runtime` above the `metadata` `useMemo` in `pages/anime/[id].tsx` (they were referenced before declaration after the early-return refactor).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f9b0d02-5ff4-47bd-b5be-3916a7c83734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f9b0d02-5ff4-47bd-b5be-3916a7c83734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

